### PR TITLE
Add default assignee and reviewer 'javiyt' for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,27 @@
+---
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    assignees:
-      - "javiyt"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    assignees:
-      - "javiyt"
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    assignees:
-      - "javiyt"
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  assignees:
+  - javiyt
+  reviewers:
+  - javiyt
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  assignees:
+  - javiyt
+  reviewers:
+  - javiyt
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: daily
+  assignees:
+  - javiyt
+  reviewers:
+  - javiyt


### PR DESCRIPTION
This PR adds 'javiyt' as the default assignee and reviewer for all Dependabot updates.

This ensures that Dependabot pull requests are automatically assigned to @javiyt for review.

Automated change via a script.
