### PR TITLE
feat: Configure Mergify for queued squash-merges

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,6 +1,27 @@
-# Mergify configuration - auto-merge for javiyt's PRs after CI passes
+# Mergify configuration - queue and squash-merge javiyt's PRs after CI passes
+merge_queue:
+  max_parallel_checks: 1
+
+queue_rules:
+  - name: default
+    batch_size: 1
+    merge_method: squash
+    update_method: rebase
+    queue_conditions:
+      - "author=javiyt"
+      - "status-success=*"
+      - "base=main"
+      - "-conflict"
+      - "-draft"
+    merge_conditions:
+      - "author=javiyt"
+      - "status-success=*"
+      - "base=main"
+      - "-conflict"
+      - "-draft"
+
 pull_request_rules:
-  - name: Automatic merge for javiyt's PRs after CI passes
+  - name: Queue javiyt's PRs after CI passes
     conditions:
       - "author=javiyt"
       - "status-success=*"
@@ -8,6 +29,5 @@ pull_request_rules:
       - "-conflict"
       - "-draft"
     actions:
-      rebase: {}
-      merge:
-        method: squash
+      queue:
+        name: default

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -39,6 +39,6 @@ Hugo JSON exports are ignored by Git and regenerated during CI and Pages deploym
 
 `catalog-sync.yml` runs `sync --resume`. If Spotify returns a 429 that cannot be waited out inside the job, the sync command records completed artists in SQLite, writes a partial snapshot, and the workflow still opens or updates the catalog PR with that checkpoint before failing the job. The next scheduled or manual run resumes from the latest compatible partial run and skips artists whose Spotify IDs have not changed.
 
-Mergify is configured only to keep matching PRs up to date. It does not merge PRs; merge decisions are left to GitHub branch protection and the explicit auto-merge request created by `catalog-sync.yml`.
+Mergify queues matching PRs and squash-merges them after CI passes. The queue is configured for in-place checks (`max_parallel_checks: 1`, `batch_size: 1`, identical queue and merge conditions) so it remains compatible with `main` requiring branches to be up to date before merging.
 
 See [Security](security.md), [End-to-end verification](e2e.md) and [Release readiness](release-readiness.md) for the approval and release checklist.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -25,7 +25,7 @@ This is the acceptance checklist for the v2 rebuild.
 | 19 | PR includes readable summary. | Done | `scripts/automation/catalog-pr-body.sh` |
 | 20 | Automatic approval only for allowed paths. | Done | `catalog-review-guard.sh` |
 | 21 | Code changes are never auto-approved. | Done | blocked path guard |
-| 22 | Auto-merge respects `main` protection. | Done | GitHub auto-merge, Mergify merge disabled |
+| 22 | Auto-merge respects `main` protection. | Done | Mergify in-place merge queue |
 | 23 | Merge to `main` deploys Pages. | Done | `pages.yml` |
 | 24 | Secrets are not leaked. | Done | server-side Spotify only; no secrets in exports |
 | 25 | Documentation reproduces the system from zero. | Done | README, operations, automation, e2e docs |


### PR DESCRIPTION
This commit configures Mergify to use a merge queue for pull requests authored by `javiyt`.

The merge queue is set up to:
- Squash-merge PRs.
- Use an in-place check strategy (`max_parallel_checks: 1`, `batch_size: 1`) to ensure compatibility with GitHub branch protection requiring branches to be up to date before merging.
- Automatically queue PRs when all CI checks pass, targeting the `main` branch, and are not in a draft or conflicted state.

This change streamlines the merging process for maintainer PRs by automating the merge and rebase steps while respecting branch protection rules.

The documentation in `docs/automation.md` and `docs/release-readiness.md` has been updated to reflect this new Mergify configuration.