### PR TITLE
feat: Improve Spotify artist resolution and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ artists-audit-albums:
 	SPOTIFY_MARKET=$(MARKET) go run $(CLI) artists audit-albums --artist $(ARTIST) --catalog $(CATALOG) --market $(MARKET) --report $(ALBUM_REPORT)
 
 sync:
-	SPOTIFY_MARKET=$(MARKET) go run $(CLI) sync --catalog $(CATALOG) --db $(DB) --snapshot $(SNAPSHOT) --market $(MARKET)
+	SPOTIFY_MARKET=$(MARKET) go run $(CLI) sync --resume --catalog $(CATALOG) --db $(DB) --snapshot $(SNAPSHOT) --market $(MARKET)
 
 sync-all: sync
 

--- a/Makefile
+++ b/Makefile
@@ -90,16 +90,16 @@ artists-seed-db:
 	go run $(CLI) artists seed-db --catalog $(CATALOG) --db $(DB)
 
 artists-resolve-report:
-	SPOTIFY_MARKET=$(MARKET) go run $(CLI) artists resolve --non-interactive --catalog $(CATALOG) --market $(MARKET) --report $(REPORT)
+	SPOTIFY_MARKET=$(MARKET) go run $(CLI) artists resolve --non-interactive --catalog $(CATALOG) --db $(DB) --market $(MARKET) --report $(REPORT)
 
 artists-resolve-apply:
-	SPOTIFY_MARKET=$(MARKET) go run $(CLI) artists resolve --non-interactive --apply --catalog $(CATALOG) --market $(MARKET) --report $(REPORT)
+	SPOTIFY_MARKET=$(MARKET) go run $(CLI) artists resolve --non-interactive --apply --catalog $(CATALOG) --db $(DB) --market $(MARKET) --report $(REPORT)
 
 artists-resolve-interactive:
-	SPOTIFY_MARKET=$(MARKET) go run $(CLI) artists resolve --interactive --catalog $(CATALOG) --market $(MARKET)
+	SPOTIFY_MARKET=$(MARKET) go run $(CLI) artists resolve --interactive --catalog $(CATALOG) --db $(DB) --market $(MARKET)
 
 artists-review-interactive:
-	SPOTIFY_MARKET=$(MARKET) go run $(CLI) artists resolve --interactive --review-all --catalog $(CATALOG) --market $(MARKET)
+	SPOTIFY_MARKET=$(MARKET) go run $(CLI) artists resolve --interactive --review-all --catalog $(CATALOG) --db $(DB) --market $(MARKET)
 
 artists-resolve-offline:
 	go run $(CLI) artists resolve --non-interactive --catalog $(CATALOG) --candidates $(CANDIDATES) --report $(REPORT)

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ SPOTIFY_CLIENT_ID=... SPOTIFY_CLIENT_SECRET=... make sync-all
 make export
 ```
 
-Use `--resume` when a previous run saved a partial checkpoint, for example after Spotify returned a long 429 retry window. It skips artists completed in the latest compatible partial run:
+`make sync-all` runs the sync with `--resume`, so it reuses a previous partial checkpoint automatically. Use `--resume` explicitly when invoking the CLI by hand after Spotify returned a long 429 retry window. It skips artists completed in the latest compatible partial run:
 
 ```bash
 SPOTIFY_CLIENT_ID=... SPOTIFY_CLIENT_SECRET=... go run ./cmd/spotwufamily sync --resume

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ SPOTIFY_CLIENT_ID=... SPOTIFY_CLIENT_SECRET=... \
   make artists-review-interactive
 ```
 
+For artists with configured Spotify IDs, live interactive review also warns when those IDs have no album matches against MusicBrainz release groups.
+
 To compare the albums returned by configured Spotify IDs with MusicBrainz album release groups:
 
 ```bash
@@ -151,7 +153,7 @@ SPOTIFY_CLIENT_ID=... SPOTIFY_CLIENT_SECRET=... \
 
 The report is advisory. It lists matched albums, MusicBrainz albums missing from Spotify results, and Spotify albums that look suspicious or unmatched.
 
-Live Spotify artist resolution also uses MusicBrainz album evidence to discard Spotify candidates that do not match any MusicBrainz album release group for the editorial artist. Offline candidate files are not filtered this way.
+Live Spotify artist resolution uses MusicBrainz album evidence to discard Spotify candidates that do not match any MusicBrainz album release group for the editorial artist. Candidates get an extra score boost when their Spotify ID is credited on tracks from albums by configured groups with reviewed Spotify IDs. The resolver reads cached albums and tracks from SQLite before falling back to Spotify, reducing API quota usage. Offline candidate files remain deterministic and do not call Spotify or MusicBrainz.
 
 ## Sync
 

--- a/data/artists.yaml
+++ b/data/artists.yaml
@@ -1,7 +1,7 @@
-# Generated from data/groups.txt.
-# Spotify IDs are intentionally empty until each entry is resolved and reviewed.
+# Editorial artist catalog.
+# Spotify IDs are intentionally reviewed before sync.
 # Entries remain disabled so validation can reject accidental syncs without a Spotify ID.
-# `roles` preserves cases where an entry appeared in more than one section of the TXT.
+# `roles` preserves cases where an entry belongs to more than one editorial category.
 
 version: 1
 artists:
@@ -383,7 +383,7 @@ artists:
     editorial_order: 30
     notes: ""
     external_url: https://open.spotify.com/artist/3KoWNgHihU3OzEuoouuycC
-    image_url: https://i.scdn.co/image/ab67616d0000b27347375f55881b37edac2c295d
+    image_url: https://i.scdn.co/image/ab67616d0000b273cfbe63f7a2840fbe1915d63b
   - slug: theodore-unit
     name: Theodore Unit
     spotify_id: 3etQyCmhwVq3MCsOWAqgSq
@@ -603,16 +603,14 @@ artists:
     image_url: https://i.scdn.co/image/ab67616d0000b273a31041c86803171f6d98914c
   - slug: don-staten
     name: Don Staten
-    spotify_id: 49o2DS2tAQf2DMjkOtdv5J
+    spotify_id: ""
     category: affiliate_artist
     roles:
       - affiliate_artist
     aliases: []
-    enabled: true
+    enabled: false
     editorial_order: 48
     notes: ""
-    external_url: https://open.spotify.com/artist/49o2DS2tAQf2DMjkOtdv5J
-    image_url: https://i.scdn.co/image/ab67616d0000b273a8843d7b06b0f916b21595aa
   - slug: dr-ama-aka-dark-skinned-assassin
     name: Dr. Ama Aka Dark Skinned Assassin
     spotify_id: ""
@@ -692,7 +690,7 @@ artists:
     editorial_order: 54
     notes: ""
     external_url: https://open.spotify.com/artist/59h4urZSPlBLaT0YharjOM
-    image_url: https://i.scdn.co/image/ab6761610000e5eb6a7ca61e271800d2fdb92e16
+    image_url: https://i.scdn.co/image/ab6761610000e5eb7d3c46e8d77ad0bb78d279db
   - slug: intell
     name: Intell
     spotify_id: 4jITyKWjSTPCdzK1iM5eaA
@@ -735,6 +733,10 @@ artists:
   - slug: killa-sin
     name: Killa Sin
     spotify_id: 67XIntxIqJFHkWpewJcrOb
+    spotify_ids:
+      - 53dhUXHXSM7X5SL33JX1Jy
+      - 1YOd9jtfZkGy1eCRiZbuiQ
+      - 7mYFvApe9zG6Zi2C6wKyDk
     genres:
       - boom bap
     category: affiliate_artist
@@ -792,6 +794,8 @@ artists:
   - slug: lounge-lo
     name: Lounge Lo
     spotify_id: 3nksXkEKKByUQDyUB23ftO
+    spotify_ids:
+      - 5FjoaoTbHpCoo70fijg3mv
     category: affiliate_artist
     roles:
       - affiliate_artist
@@ -800,6 +804,7 @@ artists:
     editorial_order: 62
     notes: ""
     external_url: https://open.spotify.com/artist/3nksXkEKKByUQDyUB23ftO
+    image_url: https://i.scdn.co/image/ab67616d0000b273b644998a7b1aca26fc36a834
   - slug: piro
     name: PiRo
     spotify_id: 06jtqet6GMetHMxOznw0zK
@@ -939,14 +944,16 @@ artists:
     image_url: https://i.scdn.co/image/ab67616d0000b273786ca892971448a1111b5dc0
   - slug: solomon-childs
     name: Solomon Childs
-    spotify_id: ""
+    spotify_id: 6rp60Uul0bpZWR6B3a6wCc
     category: affiliate_artist
     roles:
       - affiliate_artist
     aliases: []
-    enabled: false
+    enabled: true
     editorial_order: 73
     notes: ""
+    external_url: https://open.spotify.com/artist/6rp60Uul0bpZWR6B3a6wCc
+    image_url: https://i.scdn.co/image/14b6a5ae3abe37260c5a1dff42350739075ab63c
   - slug: streetlife
     name: Streetlife
     spotify_id: 0FCYBhXjpfQIQWNKiVEDg5
@@ -1012,17 +1019,27 @@ artists:
     image_url: https://i.scdn.co/image/ab67616d0000b273b3e40941f62881b981ffd9cc
   - slug: young-justice
     name: Young Justice
-    spotify_id: ""
+    spotify_id: 1r9Dad3vzvp6DQoCf9VvAv
+    genres:
+      - underground hip hop
     category: affiliate_artist
     roles:
       - affiliate_artist
     aliases: []
-    enabled: false
+    enabled: true
     editorial_order: 79
     notes: ""
+    external_url: https://open.spotify.com/artist/1r9Dad3vzvp6DQoCf9VvAv
   - slug: young-dirty-bastard
     name: Young Dirty Bastard
     spotify_id: 67XpRJysiiPNXzPe3RRicV
+    spotify_ids:
+      - 6IHiN7dGHWnx4NXm3QYVel
+      - 5WIvFW29IeBQ72ITXzTzTp
+      - 1QJM5w5GTQY5jJbd7jfV8k
+      - 3ioaPNCCq6g3JfOefsfkrH
+      - 55JXzrcE7PXBY9StZahlZs
+      - 75XV9SBXYjAAGCzKljJMW0
     category: affiliate_artist
     roles:
       - affiliate_artist
@@ -1046,6 +1063,9 @@ artists:
   - slug: blue-raspberry
     name: Blue Raspberry
     spotify_id: 60FWCT8KxqA3J5Ny7g6ZXT
+    spotify_ids:
+      - 4z1UL8FpVVj12kNlaX5GRR
+      - 0fIiPVm7ppB6qAmnndaDIX
     category: affiliate_artist
     roles:
       - affiliate_artist
@@ -1079,6 +1099,8 @@ artists:
   - slug: suga-bang-bang
     name: Suga Bang Bang
     spotify_id: 4Ri221vy0Nd7G9TNSmoh6e
+    spotify_ids:
+      - 6wxwTwZTsx0NiirVq59gpi
     category: affiliate_artist
     roles:
       - affiliate_artist
@@ -1329,10 +1351,13 @@ artists:
   - slug: pete-rock
     name: Pete Rock
     spotify_id: 3BeQqzKdlARoOd6y30kCO2
+    spotify_ids:
+      - 3fJ60AcIgLzQkVitEvA7uq
     genres:
       - boom bap
       - east coast hip hop
       - jazz rap
+      - old school hip hop
     category: collaborator
     roles:
       - collaborator

--- a/docs/musicbrainz.md
+++ b/docs/musicbrainz.md
@@ -26,4 +26,4 @@ The report sections are:
 
 Use this report to decide whether an artist needs more Spotify profile IDs, a corrected primary ID or manual review of suspicious releases.
 
-Spotify artist resolution also uses MusicBrainz as album evidence when live Spotify search is enabled. If MusicBrainz has album release groups for the editorial artist, Spotify candidates whose album list has no normalized match are discarded as noise before ranking. Offline `--candidates` resolution remains deterministic and does not call MusicBrainz.
+Spotify artist resolution also uses MusicBrainz as album evidence when live Spotify search is enabled. If MusicBrainz has album release groups for the editorial artist, Spotify candidates whose album list has no normalized match are discarded as noise before ranking unless they have track-credit evidence from configured groups. Album and track lookups are read from SQLite first and fall back to Spotify only on cache misses. Offline `--candidates` resolution remains deterministic and does not call MusicBrainz.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -62,7 +62,7 @@ To review the full YAML, including artists that already have a Spotify ID:
 SPOTIFY_CLIENT_ID=... SPOTIFY_CLIENT_SECRET=... make artists-review-interactive
 ```
 
-For artists with an existing ID, the prompt shows current Spotify profiles and lets you keep them, replace the primary ID with a candidate, add one or more candidates as additional IDs with `aN` or `aN,aM` such as `a2,a1`, clear all IDs, skip, or save and quit.
+For artists with an existing ID, the prompt shows current Spotify profiles and MusicBrainz warnings when configured Spotify albums do not match known MusicBrainz release groups. Candidate scoring also highlights `track_evidence` when a candidate appears on tracks from albums by configured groups with reviewed Spotify IDs. Live resolution reads cached albums and tracks from SQLite before calling Spotify, so a freshly synced catalog reduces API quota pressure. The prompt lets you keep the current IDs, replace the primary ID with a candidate, add one or more candidates as additional IDs with `aN` or `aN,aM` such as `a2,a1`, clear all IDs, skip, or save and quit.
 
 Audit reviewed Spotify IDs against MusicBrainz album release groups:
 

--- a/docs/spotify.md
+++ b/docs/spotify.md
@@ -61,6 +61,8 @@ SPOTIFY_CLIENT_ID=... SPOTIFY_CLIENT_SECRET=... \
 
 Use the candidate number to write that Spotify ID, `s` to skip, or `q` to save selected changes and quit.
 
+Live resolution uses `data/catalog.db` as a cache for synced albums, tracks and credits before making extra Spotify album/track calls. Pass `--db` when using a non-default catalog database.
+
 For deterministic local testing, it can still use a local JSON candidate file:
 
 ```bash

--- a/internal/adapters/inbound/cli/cli.go
+++ b/internal/adapters/inbound/cli/cli.go
@@ -1466,7 +1466,7 @@ func artistAlbumAuditSpotifyFetcher(options artistAlbumAuditOptions, progress fu
 
 func executeArtistsResolve(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer, store artists.CatalogStore) int {
 	if hasHelp(args) {
-		_, _ = fmt.Fprintln(stdout, "usage: spotwufamily artists resolve [--interactive|--non-interactive] [--review-all] [--apply] [--min-score 95] [--min-score-gap 10] [--enable-applied] [--quiet] [--candidates data/artist-candidates.example.json] [--report report.md] [--catalog data/artists.yaml] [--market ES]")
+		_, _ = fmt.Fprintln(stdout, "usage: spotwufamily artists resolve [--interactive|--non-interactive] [--review-all] [--apply] [--min-score 95] [--min-score-gap 10] [--enable-applied] [--quiet] [--candidates data/artist-candidates.example.json] [--report report.md] [--catalog data/artists.yaml] [--db data/catalog.db] [--market ES]")
 		return 0
 	}
 
@@ -1475,11 +1475,12 @@ func executeArtistsResolve(ctx context.Context, args []string, stdin io.Reader, 
 		_, _ = fmt.Fprintf(stderr, "artists resolve: %v\n", err)
 		return 2
 	}
-	searcher, err := resolveSearcher(options, spotifyProgress(stderr, options.quiet))
+	searcher, cleanup, err := resolveSearcher(ctx, options, spotifyProgress(stderr, options.quiet))
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "artists resolve: %v\n", err)
 		return 1
 	}
+	defer cleanup()
 	if options.interactive || !options.nonInteractive {
 		return executeArtistsResolveInteractive(ctx, stdin, stdout, stderr, store, searcher, options)
 	}
@@ -1531,6 +1532,7 @@ type resolveOptions struct {
 	catalogPath    string
 	candidatesPath string
 	reportPath     string
+	dbPath         string
 	market         string
 	interactive    bool
 	nonInteractive bool
@@ -1543,7 +1545,7 @@ type resolveOptions struct {
 }
 
 func parseResolveOptions(args []string) (resolveOptions, error) {
-	options := resolveOptions{catalogPath: defaultCatalogPath, reportPath: "-", minScore: 95, minScoreGap: 10}
+	options := resolveOptions{catalogPath: defaultCatalogPath, dbPath: defaultDatabasePath, reportPath: "-", minScore: 95, minScoreGap: 10}
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -1585,6 +1587,12 @@ func parseResolveOptions(args []string) (resolveOptions, error) {
 				return resolveOptions{}, fmt.Errorf("--catalog requires a value")
 			}
 			options.catalogPath = args[i]
+		case "--db":
+			i++
+			if i >= len(args) {
+				return resolveOptions{}, fmt.Errorf("--db requires a value")
+			}
+			options.dbPath = args[i]
 		case "--candidates":
 			i++
 			if i >= len(args) {
@@ -1649,7 +1657,7 @@ func executeArtistsResolveInteractive(ctx context.Context, stdin io.Reader, stdo
 			continue
 		}
 
-		candidates, err := searcher.SearchArtistCandidates(ctx, *artist)
+		candidates, err := searchInteractiveArtistCandidates(ctx, searcher, *artist, c)
 		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "artists resolve: search %s: %v\n", artist.Slug, err)
 			skipped++
@@ -1667,6 +1675,7 @@ func executeArtistsResolveInteractive(ctx context.Context, stdin io.Reader, stdo
 				}
 				_, _ = fmt.Fprintf(stdout, "  - %s | %s | %s\n", spotifyID, spotifyArtistURL(catalog.ArtistCandidate{SpotifyID: spotifyID}), marker)
 			}
+			printConfiguredSpotifyIDWarnings(ctx, stdout, stderr, searcher, *artist)
 		}
 		if len(artist.Aliases) > 0 {
 			_, _ = fmt.Fprintf(stdout, "aliases: %s\n", strings.Join(artist.Aliases, ", "))
@@ -1883,6 +1892,67 @@ func printInteractiveResolveSummary(stdout io.Writer, applied, skipped, kept, cl
 	_, _ = fmt.Fprintf(stdout, "interactive resolve: applied=%d skipped=%d kept=%d cleared=%d\n", applied, skipped, kept, cleared)
 }
 
+func searchInteractiveArtistCandidates(ctx context.Context, searcher artists.CandidateSearcher, artist catalog.Artist, c catalog.EditorialCatalog) ([]catalog.ArtistCandidate, error) {
+	if contextual, ok := searcher.(artists.CatalogAwareCandidateSearcher); ok {
+		return contextual.SearchArtistCandidatesWithCatalog(ctx, artist, c)
+	}
+	return searcher.SearchArtistCandidates(ctx, artist)
+}
+
+type configuredSpotifyIDReviewer interface {
+	ReviewConfiguredSpotifyIDs(context.Context, catalog.Artist) ([]artists.ConfiguredSpotifyIDWarning, error)
+}
+
+func printConfiguredSpotifyIDWarnings(ctx context.Context, stdout, stderr io.Writer, searcher artists.CandidateSearcher, artist catalog.Artist) {
+	reviewer, ok := searcher.(configuredSpotifyIDReviewer)
+	if !ok {
+		return
+	}
+	warnings, err := reviewer.ReviewConfiguredSpotifyIDs(ctx, artist)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "artists resolve: review current Spotify IDs %s: %v\n", artist.Slug, err)
+		return
+	}
+	if len(warnings) == 0 {
+		return
+	}
+
+	_, _ = fmt.Fprintln(stdout, "MusicBrainz warnings:")
+	for _, warning := range warnings {
+		_, _ = fmt.Fprintf(stdout, "  - %s: %s (spotify_albums=%d musicbrainz_albums=%d matched=%d)\n",
+			warning.SpotifyID,
+			warning.Reason,
+			warning.SpotifyAlbumCount,
+			warning.MusicBrainzAlbumCount,
+			warning.MatchedAlbumCount,
+		)
+		if len(warning.SpotifyAlbums) > 0 {
+			_, _ = fmt.Fprintf(stdout, "    Spotify sample: %s\n", formatAuditedAlbumSample(warning.SpotifyAlbums))
+		}
+		if len(warning.MusicBrainzAlbums) > 0 {
+			_, _ = fmt.Fprintf(stdout, "    MusicBrainz sample: %s\n", formatAuditedAlbumSample(warning.MusicBrainzAlbums))
+		}
+	}
+}
+
+func formatAuditedAlbumSample(albums []artists.AuditedAlbum) string {
+	parts := make([]string, 0, len(albums))
+	for _, album := range albums {
+		title := strings.TrimSpace(album.Title)
+		if title == "" {
+			title = album.ID
+		}
+		if album.Year != "" {
+			title += " (" + album.Year + ")"
+		}
+		parts = append(parts, title)
+	}
+	if len(parts) == 0 {
+		return "-"
+	}
+	return strings.Join(parts, "; ")
+}
+
 func printInteractiveMatches(stdout io.Writer, matches []catalog.CandidateMatch, limit int) {
 	if limit > len(matches) {
 		limit = len(matches)
@@ -1898,7 +1968,11 @@ func printInteractiveMatches(stdout io.Writer, matches []catalog.CandidateMatch,
 		if genres == "" {
 			genres = "-"
 		}
-		_, _ = fmt.Fprintf(stdout, "  %d. %s | %s | %s | score=%d confidence=%s popularity=%d followers=%d genres=%s\n",
+		evidence := strings.Join(candidate.RelatedArtistEvidence, "; ")
+		if evidence != "" {
+			evidence = " track_evidence=" + evidence
+		}
+		_, _ = fmt.Fprintf(stdout, "  %d. %s | %s | %s | score=%d confidence=%s popularity=%d followers=%d genres=%s%s\n",
 			index+1,
 			candidate.Name,
 			candidate.SpotifyID,
@@ -1908,6 +1982,7 @@ func printInteractiveMatches(stdout io.Writer, matches []catalog.CandidateMatch,
 			candidate.Popularity,
 			candidate.Followers,
 			genres,
+			evidence,
 		)
 	}
 }
@@ -2012,15 +2087,16 @@ func spotifyArtistURL(candidate catalog.ArtistCandidate) string {
 	return "https://open.spotify.com/artist/" + candidate.SpotifyID
 }
 
-func resolveSearcher(options resolveOptions, progress func(spotifyadapter.ProgressEvent)) (artists.CandidateSearcher, error) {
+func resolveSearcher(ctx context.Context, options resolveOptions, progress func(spotifyadapter.ProgressEvent)) (artists.CandidateSearcher, func(), error) {
 	if options.candidatesPath != "" {
-		return jsoncandidates.NewSearcher(options.candidatesPath)
+		searcher, err := jsoncandidates.NewSearcher(options.candidatesPath)
+		return searcher, func() {}, err
 	}
 
 	clientID := os.Getenv("SPOTIFY_CLIENT_ID")
 	clientSecret := os.Getenv("SPOTIFY_CLIENT_SECRET")
 	if clientID == "" || clientSecret == "" {
-		return nil, fmt.Errorf("SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET are required when --candidates is not provided")
+		return nil, func() {}, fmt.Errorf("SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET are required when --candidates is not provided")
 	}
 
 	market := options.market
@@ -2036,13 +2112,23 @@ func resolveSearcher(options resolveOptions, progress func(spotifyadapter.Progre
 		Progress:      progress,
 	})
 	if err != nil {
-		return nil, err
+		return nil, func() {}, err
+	}
+	cacheDatabase, err := sqliteadapter.Open(options.dbPath)
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("open cache database: %w", err)
+	}
+	cleanup := func() { _ = cacheDatabase.Close() }
+	if err := cacheDatabase.Migrate(ctx); err != nil {
+		cleanup()
+		return nil, func() {}, fmt.Errorf("migrate cache database: %w", err)
 	}
 	musicBrainzClient := musicbrainz.NewClient(musicbrainz.Config{
 		UserAgent: os.Getenv("MUSICBRAINZ_USER_AGENT"),
 	})
+	cachedSpotify := artists.NewCachedSpotifyAlbumFetcher(cacheDatabase, spotifyClient)
 
-	return artists.NewAlbumEvidenceCandidateSearcher(spotifyClient, spotifyClient, musicBrainzClient), nil
+	return artists.NewAlbumEvidenceCandidateSearcher(spotifyClient, cachedSpotify, musicBrainzClient), cleanup, nil
 }
 
 func executeArtistsValidate(ctx context.Context, args []string, stdout, stderr io.Writer, store artists.CatalogStore) int {

--- a/internal/adapters/inbound/cli/interactive_autosave_test.go
+++ b/internal/adapters/inbound/cli/interactive_autosave_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/javiyt/spotwufamily/internal/application/artists"
 	"github.com/javiyt/spotwufamily/internal/domain/catalog"
 	"github.com/stretchr/testify/require"
 )
@@ -33,6 +34,23 @@ func (flakyInteractiveSearcher) SearchArtistCandidates(_ context.Context, artist
 		return nil, errors.New("musicbrainz timeout")
 	}
 	return []catalog.ArtistCandidate{{Name: "Wu-Tang Clan", SpotifyID: "34EP7KEpOjXcM2TCat1ISk"}}, nil
+}
+
+type warningInteractiveSearcher struct{}
+
+func (warningInteractiveSearcher) SearchArtistCandidates(context.Context, catalog.Artist) ([]catalog.ArtistCandidate, error) {
+	return nil, nil
+}
+
+func (warningInteractiveSearcher) ReviewConfiguredSpotifyIDs(context.Context, catalog.Artist) ([]artists.ConfiguredSpotifyIDWarning, error) {
+	return []artists.ConfiguredSpotifyIDWarning{{
+		SpotifyID:             "1111111111111111111111",
+		Reason:                "no Spotify albums matched MusicBrainz release groups",
+		SpotifyAlbumCount:     1,
+		MusicBrainzAlbumCount: 1,
+		SpotifyAlbums:         []artists.AuditedAlbum{{ID: "album-2", Title: "Unrelated Album", Year: "2020"}},
+		MusicBrainzAlbums:     []artists.AuditedAlbum{{ID: "mb-1", Title: "Enter the Wu-Tang (36 Chambers)", Year: "1993"}},
+	}}, nil
 }
 
 func TestExecuteArtistsResolveInteractiveAutosavesAndContinuesAfterSearchError(t *testing.T) {
@@ -77,4 +95,55 @@ func TestExecuteArtistsResolveInteractiveAutosavesAndContinuesAfterSearchError(t
 	require.Contains(t, stdout.String(), "interactive resolve: applied=1 skipped=1 kept=0 cleared=0")
 	require.Equal(t, "34EP7KEpOjXcM2TCat1ISk", store.catalog.Artists[0].SpotifyID)
 	require.GreaterOrEqual(t, store.saveCount, 2)
+}
+
+func TestExecuteArtistsResolveInteractiveShowsMusicBrainzWarningForConfiguredSpotifyID(t *testing.T) {
+	store := &interactiveStore{catalog: catalog.EditorialCatalog{
+		Version: 1,
+		Artists: []catalog.Artist{{
+			Slug:           "wu-tang-clan",
+			Name:           "Wu-Tang Clan",
+			SpotifyID:      "1111111111111111111111",
+			Category:       catalog.CategoryCore,
+			Roles:          []catalog.Category{catalog.CategoryCore},
+			Aliases:        []string{},
+			EditorialOrder: 1,
+		}},
+	}}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := executeArtistsResolveInteractive(
+		context.Background(),
+		strings.NewReader("k\n"),
+		&stdout,
+		&stderr,
+		store,
+		warningInteractiveSearcher{},
+		resolveOptions{catalogPath: "artists.yaml", reviewAll: true},
+	)
+
+	require.Equal(t, 0, code)
+	require.Empty(t, stderr.String())
+	require.Contains(t, stdout.String(), "MusicBrainz warnings:")
+	require.Contains(t, stdout.String(), "1111111111111111111111: no Spotify albums matched MusicBrainz release groups")
+	require.Contains(t, stdout.String(), "Spotify sample: Unrelated Album (2020)")
+	require.Contains(t, stdout.String(), "MusicBrainz sample: Enter the Wu-Tang (36 Chambers) (1993)")
+	require.Contains(t, stdout.String(), "interactive resolve: applied=0 skipped=0 kept=1 cleared=0")
+}
+
+func TestPrintInteractiveMatchesShowsTrackEvidence(t *testing.T) {
+	var stdout bytes.Buffer
+
+	printInteractiveMatches(&stdout, []catalog.CandidateMatch{{
+		Candidate: catalog.ArtistCandidate{
+			Name:                  "Solomon Childs",
+			SpotifyID:             "1111111111111111111111",
+			RelatedArtistEvidence: []string{"credited on Configured Group track \"Feature Track\""},
+		},
+		Score:      95,
+		Confidence: "strong",
+	}}, 1)
+
+	require.Contains(t, stdout.String(), "track_evidence=credited on Configured Group track")
 }

--- a/internal/adapters/outbound/spotify/client.go
+++ b/internal/adapters/outbound/spotify/client.go
@@ -28,9 +28,27 @@ const (
 )
 
 var (
-	ErrPermanent = errors.New("permanent Spotify error")
-	ErrTemporary = errors.New("temporary Spotify error")
+	ErrPermanent     = errors.New("permanent Spotify error")
+	ErrTemporary     = errors.New("temporary Spotify error")
+	ErrRateLimited   = fmt.Errorf("%w: Spotify rate limit exceeded", ErrTemporary)
+	ErrQuotaExceeded = fmt.Errorf("%w: Spotify quota exceeded", ErrRateLimited)
 )
+
+type rateLimitAbortError struct {
+	err error
+}
+
+func (e rateLimitAbortError) Error() string {
+	return e.err.Error()
+}
+
+func (e rateLimitAbortError) Unwrap() error {
+	return e.err
+}
+
+func (e rateLimitAbortError) AbortSync() bool {
+	return true
+}
 
 type Config struct {
 	ClientID      string
@@ -394,15 +412,24 @@ func (c *Client) doWithRetry(ctx context.Context, options retryOptions, buildReq
 			c.emitProgress(event)
 			return data, nil
 		case resp.StatusCode == http.StatusTooManyRequests:
-			lastErr = spotifyHTTPError(resp.StatusCode, data, ErrTemporary)
+			quotaExceeded := spotifyQuotaExceeded(data)
+			kind := ErrRateLimited
+			if quotaExceeded {
+				kind = ErrQuotaExceeded
+			}
+			lastErr = spotifyHTTPError(resp.StatusCode, data, kind)
 			wait := retryAfter(resp.Header)
 			event.Stage = "request_retrying"
 			event.Wait = wait
 			event.Err = lastErr
 			c.emitProgress(event)
-			if c.maxRetryAfter > 0 && wait > c.maxRetryAfter {
+			if quotaExceeded || c.maxRetryAfter > 0 && wait > c.maxRetryAfter {
 				event.Stage = "request_failed"
-				event.Err = fmt.Errorf("%w: Spotify requested retry after %s, above max wait %s: %w", ErrTemporary, wait, c.maxRetryAfter, lastErr)
+				abortErr := fmt.Errorf("%w: Spotify quota exceeded: %w", kind, lastErr)
+				if c.maxRetryAfter > 0 && wait > c.maxRetryAfter {
+					abortErr = fmt.Errorf("%w: Spotify requested retry after %s, above max wait %s: %w", kind, wait, c.maxRetryAfter, lastErr)
+				}
+				event.Err = spotifyRateLimitAbortError(abortErr)
 				c.emitProgress(event)
 				return nil, event.Err
 			}
@@ -480,6 +507,14 @@ func spotifyHTTPError(statusCode int, body []byte, kind error) error {
 	}
 
 	return fmt.Errorf("%w: HTTP %d: %s", kind, statusCode, message)
+}
+
+func spotifyRateLimitAbortError(err error) error {
+	return rateLimitAbortError{err: err}
+}
+
+func spotifyQuotaExceeded(body []byte) bool {
+	return strings.Contains(strings.ToUpper(string(body)), "QUOTA_EXCEEDED")
 }
 
 func retryAfter(header http.Header) time.Duration {

--- a/internal/adapters/outbound/spotify/client_test.go
+++ b/internal/adapters/outbound/spotify/client_test.go
@@ -169,6 +169,8 @@ func TestRateLimitAboveMaxRetryAfterReturnsError(t *testing.T) {
 	_, err := client.SearchArtists(context.Background(), "Wu-Tang Clan", 20)
 
 	require.Error(t, err)
+	require.ErrorIs(t, err, spotifyadapter.ErrQuotaExceeded)
+	require.ErrorIs(t, err, spotifyadapter.ErrRateLimited)
 	require.ErrorIs(t, err, spotifyadapter.ErrTemporary)
 	require.Contains(t, err.Error(), "above max wait")
 	require.Equal(t, int32(1), calls.Load())

--- a/internal/adapters/outbound/sqlite/database_test.go
+++ b/internal/adapters/outbound/sqlite/database_test.go
@@ -2,6 +2,7 @@ package sqlite_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	sqliteadapter "github.com/javiyt/spotwufamily/internal/adapters/outbound/sqlite"
+	"github.com/javiyt/spotwufamily/internal/application/artists"
 	"github.com/javiyt/spotwufamily/internal/application/catalogsync"
 	"github.com/javiyt/spotwufamily/internal/domain/catalog"
 	"github.com/stretchr/testify/require"
@@ -295,6 +297,68 @@ func TestLoadExportCatalogBuildsSpotifyURLForConfiguredArtistsWithoutSyncedMetad
 	require.Len(t, exported.Artists, 1)
 	require.Equal(t, "https://open.spotify.com/artist/5wwleY8YnxnutxOExPVoJb", exported.Artists[0].SpotifyURL)
 	require.Equal(t, "https://i.scdn.co/image/killarmy", exported.Artists[0].ImageURL)
+}
+
+func TestCachedSpotifyAlbumFetcherReadsSyncedArtistAlbumsAndTracks(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "catalog.db")
+	database := openMigratedDatabase(t, ctx, dbPath)
+	defer func() { require.NoError(t, database.Close()) }()
+
+	configuredArtist := catalog.Artist{
+		Slug:      "wu-tang-clan",
+		Name:      "Wu-Tang Clan",
+		SpotifyID: "artist-1",
+		Category:  catalog.CategoryCore,
+		Roles:     []catalog.Category{catalog.CategoryCore},
+		Enabled:   true,
+	}
+	require.NoError(t, database.SaveConfiguredArtists(ctx, []catalog.Artist{configuredArtist}))
+	runID, err := database.BeginSyncRun(ctx, catalogsync.SyncRun{StartedAt: fixedTime(), Market: "ES"})
+	require.NoError(t, err)
+	_, err = database.SaveArtistCatalog(
+		ctx,
+		runID,
+		configuredArtist,
+		catalog.ArtistCandidate{SpotifyID: "artist-1", Name: "Wu-Tang Clan"},
+		[]catalog.ReleaseTracks{{
+			Release: catalog.Release{
+				SpotifyID:   "album-1",
+				Name:        "Album One",
+				AlbumType:   "album",
+				ReleaseDate: "1993-11-09",
+				Artists:     []catalog.ArtistCandidate{{SpotifyID: "artist-1", Name: "Wu-Tang Clan"}},
+			},
+			Tracks: []catalog.Track{{
+				SpotifyID:   "track-1",
+				Name:        "Track One",
+				DiscNumber:  1,
+				TrackNumber: 1,
+				Artists: []catalog.ArtistCandidate{
+					{SpotifyID: "artist-1", Name: "Wu-Tang Clan"},
+					{SpotifyID: "featured-artist", Name: "Featured Artist"},
+				},
+			}},
+		}},
+		fixedTime(),
+	)
+	require.NoError(t, err)
+
+	albums, err := database.GetCachedArtistAlbums(ctx, "artist-1", []string{"album"})
+	require.NoError(t, err)
+	require.Len(t, albums, 1)
+	require.Equal(t, "album-1", albums[0].SpotifyID)
+
+	tracks, err := database.GetCachedAlbumTracks(ctx, "album-1")
+	require.NoError(t, err)
+	require.Len(t, tracks, 1)
+	require.Equal(t, "track-1", tracks[0].SpotifyID)
+	require.Equal(t, "featured-artist", tracks[0].Artists[1].SpotifyID)
+
+	_, err = database.GetCachedArtistAlbums(ctx, "missing-artist", []string{"album"})
+	require.ErrorIs(t, err, artists.ErrCacheMiss)
+	_, err = database.GetCachedAlbumTracks(ctx, "missing-album")
+	require.True(t, errors.Is(err, artists.ErrCacheMiss))
 }
 
 func openMigratedDatabase(t *testing.T, ctx context.Context, path string) *sqliteadapter.Database {

--- a/internal/adapters/outbound/sqlite/spotify_cache.go
+++ b/internal/adapters/outbound/sqlite/spotify_cache.go
@@ -1,0 +1,195 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/javiyt/spotwufamily/internal/application/artists"
+	"github.com/javiyt/spotwufamily/internal/domain/catalog"
+)
+
+func (d *Database) GetCachedArtistAlbums(ctx context.Context, spotifyID string, groups []string) ([]catalog.Release, error) {
+	if spotifyID == "" {
+		return nil, artists.ErrCacheMiss
+	}
+
+	groupSet := map[string]struct{}{}
+	for _, group := range groups {
+		group = strings.TrimSpace(group)
+		if group != "" {
+			groupSet[group] = struct{}{}
+		}
+	}
+
+	rows, err := d.db.QueryContext(ctx, `
+SELECT DISTINCT
+  a.spotify_id,
+  a.name,
+  a.album_type,
+  a.release_date,
+  a.release_date_precision,
+  a.label,
+  a.total_tracks,
+  COALESCE(eu.url, '')
+FROM albums a
+LEFT JOIN artist_albums aa ON aa.album_id = a.spotify_id AND aa.active = 1
+LEFT JOIN configured_artist_spotify_ids casi ON casi.artist_slug = aa.configured_artist_slug
+LEFT JOIN album_artists ar ON ar.album_id = a.spotify_id
+LEFT JOIN external_urls eu ON eu.owner_type = 'album' AND eu.owner_id = a.spotify_id AND eu.provider = 'spotify'
+WHERE a.active = 1
+  AND (casi.spotify_id = ? OR ar.artist_id = ?)
+ORDER BY a.release_date DESC, a.name, a.spotify_id`,
+		spotifyID,
+		spotifyID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("read cached Spotify artist albums %s: %w", spotifyID, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var releases []catalog.Release
+	for rows.Next() {
+		var release catalog.Release
+		if err := rows.Scan(
+			&release.SpotifyID,
+			&release.Name,
+			&release.AlbumType,
+			&release.ReleaseDate,
+			&release.ReleaseDatePrecision,
+			&release.Label,
+			&release.TotalTracks,
+			&release.URL,
+		); err != nil {
+			return nil, fmt.Errorf("scan cached Spotify artist album: %w", err)
+		}
+		if len(groupSet) > 0 {
+			if _, ok := groupSet[release.AlbumType]; !ok {
+				continue
+			}
+		}
+		releases = append(releases, release)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate cached Spotify artist albums: %w", err)
+	}
+	if len(releases) == 0 {
+		return nil, artists.ErrCacheMiss
+	}
+
+	return releases, nil
+}
+
+func (d *Database) GetCachedAlbumTracks(ctx context.Context, spotifyID string) ([]catalog.Track, error) {
+	if spotifyID == "" {
+		return nil, artists.ErrCacheMiss
+	}
+
+	credits, err := d.cachedTrackArtists(ctx, spotifyID)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := d.db.QueryContext(ctx, `
+SELECT
+  t.spotify_id,
+  t.name,
+  at.disc_number,
+  at.track_number,
+  t.duration_ms,
+  t.explicit,
+  t.isrc,
+  t.preview_url,
+  COALESCE(eu.url, '')
+FROM album_tracks at
+JOIN tracks t ON t.spotify_id = at.track_id
+LEFT JOIN external_urls eu ON eu.owner_type = 'track' AND eu.owner_id = t.spotify_id AND eu.provider = 'spotify'
+WHERE at.album_id = ?
+ORDER BY at.disc_number, at.track_number, t.name, t.spotify_id`,
+		spotifyID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("read cached Spotify album tracks %s: %w", spotifyID, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tracks []catalog.Track
+	for rows.Next() {
+		var track catalog.Track
+		var explicit int
+		if err := rows.Scan(
+			&track.SpotifyID,
+			&track.Name,
+			&track.DiscNumber,
+			&track.TrackNumber,
+			&track.DurationMS,
+			&explicit,
+			&track.ISRC,
+			&track.PreviewURL,
+			&track.URL,
+		); err != nil {
+			return nil, fmt.Errorf("scan cached Spotify album track: %w", err)
+		}
+		track.Explicit = explicit == 1
+		track.Artists = credits[track.SpotifyID]
+		tracks = append(tracks, track)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate cached Spotify album tracks: %w", err)
+	}
+	if len(tracks) == 0 {
+		return nil, artists.ErrCacheMiss
+	}
+
+	return tracks, nil
+}
+
+func (d *Database) cachedTrackArtists(ctx context.Context, albumID string) (map[string][]catalog.ArtistCandidate, error) {
+	rows, err := d.db.QueryContext(ctx, `
+SELECT
+  ta.track_id,
+  ar.spotify_id,
+  ar.name,
+  COALESCE(eu.url, ''),
+  COALESCE(img.url, ''),
+  COALESCE(ar.popularity, 0),
+  COALESCE(ar.followers, 0)
+FROM album_tracks at
+JOIN track_artists ta ON ta.track_id = at.track_id
+JOIN artists ar ON ar.spotify_id = ta.artist_id
+LEFT JOIN external_urls eu ON eu.owner_type = 'artist' AND eu.owner_id = ar.spotify_id AND eu.provider = 'spotify'
+LEFT JOIN images img ON img.owner_type = 'artist' AND img.owner_id = ar.spotify_id AND img.position = 0
+WHERE at.album_id = ?
+ORDER BY ta.track_id, ta.position, ar.name`,
+		albumID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("read cached Spotify track artists %s: %w", albumID, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	credits := map[string][]catalog.ArtistCandidate{}
+	for rows.Next() {
+		var trackID string
+		var candidate catalog.ArtistCandidate
+		if err := rows.Scan(
+			&trackID,
+			&candidate.SpotifyID,
+			&candidate.Name,
+			&candidate.URL,
+			&candidate.ImageURL,
+			&candidate.Popularity,
+			&candidate.Followers,
+		); err != nil {
+			return nil, fmt.Errorf("scan cached Spotify track artist: %w", err)
+		}
+		credits[trackID] = append(credits[trackID], candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate cached Spotify track artists: %w", err)
+	}
+
+	return credits, nil
+}
+
+var _ artists.SpotifyAlbumCache = (*Database)(nil)

--- a/internal/application/artists/musicbrainz_filter.go
+++ b/internal/application/artists/musicbrainz_filter.go
@@ -2,6 +2,8 @@ package artists
 
 import (
 	"context"
+	"fmt"
+	"sync"
 
 	"github.com/javiyt/spotwufamily/internal/domain/catalog"
 )
@@ -10,17 +12,67 @@ type AlbumEvidenceCandidateSearcher struct {
 	searcher    CandidateSearcher
 	spotify     SpotifyAlbumFetcher
 	musicBrainz MusicBrainzReleaseGroupSearcher
+
+	trackCreditMu     sync.Mutex
+	trackCreditCache  map[string][]configuredArtistTrackCredit
+	trackCreditErrors map[string]error
 }
 
-func NewAlbumEvidenceCandidateSearcher(searcher CandidateSearcher, spotify SpotifyAlbumFetcher, musicBrainz MusicBrainzReleaseGroupSearcher) AlbumEvidenceCandidateSearcher {
-	return AlbumEvidenceCandidateSearcher{searcher: searcher, spotify: spotify, musicBrainz: musicBrainz}
+type ConfiguredSpotifyIDWarning struct {
+	SpotifyID             string
+	Reason                string
+	SpotifyAlbumCount     int
+	MusicBrainzAlbumCount int
+	MatchedAlbumCount     int
+	SpotifyAlbums         []AuditedAlbum
+	MusicBrainzAlbums     []AuditedAlbum
 }
 
-func (s AlbumEvidenceCandidateSearcher) SearchArtistCandidates(ctx context.Context, artist catalog.Artist) ([]catalog.ArtistCandidate, error) {
+type configuredArtistTrackCredit struct {
+	ArtistID   string
+	TrackName  string
+	AlbumName  string
+	SourceName string
+}
+
+type spotifyAlbumTrackFetcher interface {
+	GetArtistAlbums(context.Context, string, []string) ([]catalog.Release, error)
+	GetAlbumTracks(context.Context, string) ([]catalog.Track, error)
+}
+
+func NewAlbumEvidenceCandidateSearcher(searcher CandidateSearcher, spotify SpotifyAlbumFetcher, musicBrainz MusicBrainzReleaseGroupSearcher) *AlbumEvidenceCandidateSearcher {
+	return &AlbumEvidenceCandidateSearcher{
+		searcher:          searcher,
+		spotify:           spotify,
+		musicBrainz:       musicBrainz,
+		trackCreditCache:  map[string][]configuredArtistTrackCredit{},
+		trackCreditErrors: map[string]error{},
+	}
+}
+
+func (s *AlbumEvidenceCandidateSearcher) SearchArtistCandidates(ctx context.Context, artist catalog.Artist) ([]catalog.ArtistCandidate, error) {
+	return s.searchArtistCandidates(ctx, artist, nil)
+}
+
+func (s *AlbumEvidenceCandidateSearcher) SearchArtistCandidatesWithCatalog(ctx context.Context, artist catalog.Artist, editorialCatalog catalog.EditorialCatalog) ([]catalog.ArtistCandidate, error) {
+	return s.searchArtistCandidates(ctx, artist, &editorialCatalog)
+}
+
+func (s *AlbumEvidenceCandidateSearcher) searchArtistCandidates(ctx context.Context, artist catalog.Artist, editorialCatalog *catalog.EditorialCatalog) ([]catalog.ArtistCandidate, error) {
 	candidates, err := s.searcher.SearchArtistCandidates(ctx, artist)
 	if err != nil {
 		return nil, err
 	}
+	if len(candidates) == 0 {
+		return candidates, nil
+	}
+
+	trackEvidence := map[string][]string{}
+	if editorialCatalog != nil {
+		trackEvidence = s.configuredArtistTrackEvidence(ctx, artist, candidates, *editorialCatalog)
+		candidates = applyTrackEvidence(candidates, trackEvidence)
+	}
+	candidates = filterResolvableCandidates(artist, candidates)
 	if len(candidates) == 0 {
 		return candidates, nil
 	}
@@ -41,10 +93,13 @@ func (s AlbumEvidenceCandidateSearcher) SearchArtistCandidates(ctx context.Conte
 		}
 		spotifyAlbums, err := s.candidateAlbums(ctx, candidate.SpotifyID)
 		if err != nil {
+			if len(trackEvidence[candidate.SpotifyID]) > 0 {
+				filtered = append(filtered, candidate)
+			}
 			continue
 		}
 		matched, _, _ := compareAlbums(spotifyAlbums, musicBrainzAlbums)
-		if len(matched) == 0 {
+		if len(matched) == 0 && len(trackEvidence[candidate.SpotifyID]) == 0 {
 			continue
 		}
 		filtered = append(filtered, candidate)
@@ -53,7 +108,212 @@ func (s AlbumEvidenceCandidateSearcher) SearchArtistCandidates(ctx context.Conte
 	return filtered, nil
 }
 
-func (s AlbumEvidenceCandidateSearcher) candidateAlbums(ctx context.Context, spotifyID string) ([]AuditedAlbum, error) {
+func (s *AlbumEvidenceCandidateSearcher) configuredArtistTrackEvidence(ctx context.Context, target catalog.Artist, candidates []catalog.ArtistCandidate, editorialCatalog catalog.EditorialCatalog) map[string][]string {
+	trackFetcher, ok := s.spotify.(spotifyAlbumTrackFetcher)
+	if !ok {
+		return nil
+	}
+
+	candidateIDs := map[string]struct{}{}
+	for _, candidate := range candidates {
+		if candidate.SpotifyID != "" {
+			candidateIDs[candidate.SpotifyID] = struct{}{}
+		}
+	}
+	if len(candidateIDs) == 0 {
+		return nil
+	}
+
+	evidence := map[string][]string{}
+	for _, source := range editorialCatalog.Artists {
+		if source.Slug == target.Slug || !isConfiguredGroup(source) || len(source.AllSpotifyIDs()) == 0 {
+			continue
+		}
+		for _, spotifyID := range source.AllSpotifyIDs() {
+			credits, err := s.configuredArtistTrackCredits(ctx, trackFetcher, source, spotifyID)
+			if err != nil {
+				continue
+			}
+			for _, credit := range credits {
+				if _, ok := candidateIDs[credit.ArtistID]; !ok {
+					continue
+				}
+				if len(evidence[credit.ArtistID]) >= 3 {
+					continue
+				}
+				evidence[credit.ArtistID] = append(evidence[credit.ArtistID], formatTrackCreditEvidence(credit))
+			}
+		}
+	}
+
+	return evidence
+}
+
+func (s *AlbumEvidenceCandidateSearcher) configuredArtistTrackCredits(ctx context.Context, trackFetcher spotifyAlbumTrackFetcher, source catalog.Artist, spotifyID string) ([]configuredArtistTrackCredit, error) {
+	s.trackCreditMu.Lock()
+	if s.trackCreditCache == nil {
+		s.trackCreditCache = map[string][]configuredArtistTrackCredit{}
+	}
+	if s.trackCreditErrors == nil {
+		s.trackCreditErrors = map[string]error{}
+	}
+	if credits, ok := s.trackCreditCache[spotifyID]; ok {
+		s.trackCreditMu.Unlock()
+		return credits, nil
+	}
+	if err, ok := s.trackCreditErrors[spotifyID]; ok {
+		s.trackCreditMu.Unlock()
+		return nil, err
+	}
+	s.trackCreditMu.Unlock()
+
+	releases, err := trackFetcher.GetArtistAlbums(ctx, spotifyID, []string{"album"})
+	if err != nil {
+		s.rememberTrackCreditError(spotifyID, err)
+		return nil, err
+	}
+
+	var credits []configuredArtistTrackCredit
+	seenAlbums := map[string]string{}
+	for _, release := range releases {
+		if release.SpotifyID == "" {
+			continue
+		}
+		if _, ok := seenAlbums[release.SpotifyID]; ok {
+			continue
+		}
+		seenAlbums[release.SpotifyID] = release.Name
+		tracks, err := trackFetcher.GetAlbumTracks(ctx, release.SpotifyID)
+		if err != nil {
+			s.rememberTrackCreditError(spotifyID, err)
+			return nil, err
+		}
+		for _, track := range tracks {
+			for _, artist := range track.Artists {
+				if artist.SpotifyID == "" || source.HasSpotifyID(artist.SpotifyID) {
+					continue
+				}
+				credits = append(credits, configuredArtistTrackCredit{
+					ArtistID:   artist.SpotifyID,
+					TrackName:  track.Name,
+					AlbumName:  release.Name,
+					SourceName: source.Name,
+				})
+			}
+		}
+	}
+
+	s.trackCreditMu.Lock()
+	s.trackCreditCache[spotifyID] = credits
+	s.trackCreditMu.Unlock()
+	return credits, nil
+}
+
+func (s *AlbumEvidenceCandidateSearcher) rememberTrackCreditError(spotifyID string, err error) {
+	s.trackCreditMu.Lock()
+	defer s.trackCreditMu.Unlock()
+	if s.trackCreditErrors == nil {
+		s.trackCreditErrors = map[string]error{}
+	}
+	s.trackCreditErrors[spotifyID] = err
+}
+
+func applyTrackEvidence(candidates []catalog.ArtistCandidate, evidence map[string][]string) []catalog.ArtistCandidate {
+	if len(evidence) == 0 {
+		return candidates
+	}
+	enriched := make([]catalog.ArtistCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if items := evidence[candidate.SpotifyID]; len(items) > 0 {
+			candidate.RelatedArtistEvidence = append(candidate.RelatedArtistEvidence, items...)
+		}
+		enriched = append(enriched, candidate)
+	}
+	return enriched
+}
+
+func filterResolvableCandidates(artist catalog.Artist, candidates []catalog.ArtistCandidate) []catalog.ArtistCandidate {
+	matches := catalog.RankCandidates(artist, candidates)
+	filtered := make([]catalog.ArtistCandidate, 0, len(candidates))
+	for _, match := range matches {
+		if match.Score >= 50 || len(match.Candidate.RelatedArtistEvidence) > 0 {
+			filtered = append(filtered, match.Candidate)
+		}
+	}
+	return filtered
+}
+
+func isConfiguredGroup(artist catalog.Artist) bool {
+	if artist.Category == catalog.CategoryCore || artist.Category == catalog.CategoryAffiliateGroup {
+		return true
+	}
+	for _, role := range artist.Roles {
+		if role == catalog.CategoryCore || role == catalog.CategoryAffiliateGroup {
+			return true
+		}
+	}
+	return false
+}
+
+func formatTrackCreditEvidence(credit configuredArtistTrackCredit) string {
+	switch {
+	case credit.SourceName != "" && credit.TrackName != "" && credit.AlbumName != "":
+		return fmt.Sprintf("credited on %s track %q from %q", credit.SourceName, credit.TrackName, credit.AlbumName)
+	case credit.SourceName != "" && credit.TrackName != "":
+		return fmt.Sprintf("credited on %s track %q", credit.SourceName, credit.TrackName)
+	case credit.SourceName != "":
+		return fmt.Sprintf("credited on %s album track", credit.SourceName)
+	default:
+		return "credited on configured artist album track"
+	}
+}
+
+func (s *AlbumEvidenceCandidateSearcher) ReviewConfiguredSpotifyIDs(ctx context.Context, artist catalog.Artist) ([]ConfiguredSpotifyIDWarning, error) {
+	spotifyIDs := artist.AllSpotifyIDs()
+	if len(spotifyIDs) == 0 {
+		return nil, nil
+	}
+
+	releaseGroups, err := s.musicBrainz.SearchArtistAlbumReleaseGroups(ctx, artist)
+	if err != nil {
+		return nil, err
+	}
+	musicBrainzAlbums := auditedMusicBrainzAlbums(releaseGroups)
+	if len(musicBrainzAlbums) == 0 {
+		return nil, nil
+	}
+
+	var warnings []ConfiguredSpotifyIDWarning
+	for _, spotifyID := range spotifyIDs {
+		spotifyAlbums, err := s.candidateAlbums(ctx, spotifyID)
+		if err != nil {
+			warnings = append(warnings, ConfiguredSpotifyIDWarning{
+				SpotifyID:             spotifyID,
+				Reason:                "could not fetch Spotify albums for configured ID",
+				MusicBrainzAlbumCount: len(musicBrainzAlbums),
+				MusicBrainzAlbums:     firstAuditedAlbums(musicBrainzAlbums, 3),
+			})
+			continue
+		}
+		matched, _, _ := compareAlbums(spotifyAlbums, musicBrainzAlbums)
+		if len(matched) > 0 {
+			continue
+		}
+		warnings = append(warnings, ConfiguredSpotifyIDWarning{
+			SpotifyID:             spotifyID,
+			Reason:                "no Spotify albums matched MusicBrainz release groups",
+			SpotifyAlbumCount:     len(spotifyAlbums),
+			MusicBrainzAlbumCount: len(musicBrainzAlbums),
+			MatchedAlbumCount:     len(matched),
+			SpotifyAlbums:         firstAuditedAlbums(spotifyAlbums, 3),
+			MusicBrainzAlbums:     firstAuditedAlbums(musicBrainzAlbums, 3),
+		})
+	}
+
+	return warnings, nil
+}
+
+func (s *AlbumEvidenceCandidateSearcher) candidateAlbums(ctx context.Context, spotifyID string) ([]AuditedAlbum, error) {
 	releases, err := s.spotify.GetArtistAlbums(ctx, spotifyID, []string{"album"})
 	if err != nil {
 		return nil, err
@@ -94,4 +354,14 @@ func auditedMusicBrainzAlbums(releaseGroups []MusicBrainzReleaseGroup) []Audited
 	}
 	sortAlbums(albums)
 	return albums
+}
+
+func firstAuditedAlbums(albums []AuditedAlbum, limit int) []AuditedAlbum {
+	if limit <= 0 || len(albums) == 0 {
+		return nil
+	}
+	if len(albums) < limit {
+		limit = len(albums)
+	}
+	return append([]AuditedAlbum(nil), albums[:limit]...)
 }

--- a/internal/application/artists/musicbrainz_filter_test.go
+++ b/internal/application/artists/musicbrainz_filter_test.go
@@ -30,6 +30,23 @@ func (failingAlbumFetcher) GetArtistAlbums(context.Context, string, []string) ([
 	return nil, errors.New("spotify albums timeout")
 }
 
+type trackCreditSpotifyFetcher struct {
+	albumsByArtist  map[string][]catalog.Release
+	tracksByAlbum   map[string][]catalog.Track
+	requestedIDs    []string
+	requestedAlbums []string
+}
+
+func (f *trackCreditSpotifyFetcher) GetArtistAlbums(_ context.Context, spotifyID string, groups []string) ([]catalog.Release, error) {
+	f.requestedIDs = append(f.requestedIDs, spotifyID)
+	return f.albumsByArtist[spotifyID], nil
+}
+
+func (f *trackCreditSpotifyFetcher) GetAlbumTracks(_ context.Context, spotifyID string) ([]catalog.Track, error) {
+	f.requestedAlbums = append(f.requestedAlbums, spotifyID)
+	return f.tracksByAlbum[spotifyID], nil
+}
+
 func TestAlbumEvidenceCandidateSearcherDiscardsCandidatesWithoutMusicBrainzAlbumMatches(t *testing.T) {
 	spotify := &albumAuditSpotifyFetcher{albumsByArtist: map[string][]catalog.Release{
 		"good-artist": {
@@ -56,6 +73,83 @@ func TestAlbumEvidenceCandidateSearcherDiscardsCandidatesWithoutMusicBrainzAlbum
 	require.NoError(t, err)
 	require.Equal(t, []catalog.ArtistCandidate{{Name: "Wu-Tang Clan", SpotifyID: "good-artist"}}, candidates)
 	require.Equal(t, []string{"good-artist", "noise-artist"}, spotify.requestedIDs)
+}
+
+func TestAlbumEvidenceCandidateSearcherAddsTrackCreditEvidenceFromConfiguredGroups(t *testing.T) {
+	spotify := &trackCreditSpotifyFetcher{
+		albumsByArtist: map[string][]catalog.Release{
+			"group-artist": {
+				{SpotifyID: "group-album", Name: "Group Album"},
+			},
+			"credited-artist": {
+				{SpotifyID: "credited-album", Name: "Unrelated Solo Album", ReleaseDate: "2020-01-01"},
+			},
+			"noise-artist": {
+				{SpotifyID: "noise-album", Name: "Noise Album", ReleaseDate: "2020-01-01"},
+			},
+		},
+		tracksByAlbum: map[string][]catalog.Track{
+			"group-album": {
+				{
+					Name: "Feature Track",
+					Artists: []catalog.ArtistCandidate{
+						{SpotifyID: "group-artist", Name: "Configured Group"},
+						{SpotifyID: "credited-artist", Name: "Solomon Childs"},
+					},
+				},
+			},
+		},
+	}
+	searcher := artists.NewAlbumEvidenceCandidateSearcher(
+		fixedCandidateSearcher{candidates: []catalog.ArtistCandidate{
+			{Name: "Solomon Childs", SpotifyID: "credited-artist"},
+			{Name: "Solomon Childs", SpotifyID: "noise-artist"},
+		}},
+		spotify,
+		albumAuditMusicBrainzSearcher{releaseGroups: []artists.MusicBrainzReleaseGroup{
+			{ID: "mb-1", Title: "Expected MusicBrainz Album", FirstReleaseDate: "1998"},
+		}},
+	)
+
+	candidates, err := searcher.SearchArtistCandidatesWithCatalog(context.Background(), catalog.Artist{
+		Slug: "solomon-childs",
+		Name: "Solomon Childs",
+	}, catalog.EditorialCatalog{Artists: []catalog.Artist{{
+		Slug:      "configured-group",
+		Name:      "Configured Group",
+		SpotifyID: "group-artist",
+		Category:  catalog.CategoryAffiliateGroup,
+	}}})
+
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	require.Equal(t, "credited-artist", candidates[0].SpotifyID)
+	require.Contains(t, candidates[0].RelatedArtistEvidence[0], "credited on Configured Group track")
+	require.Contains(t, spotify.requestedIDs, "group-artist")
+	require.Contains(t, spotify.requestedAlbums, "group-album")
+}
+
+func TestAlbumEvidenceCandidateSearcherDropsWeakCandidatesBeforeAlbumFetch(t *testing.T) {
+	spotify := &albumAuditSpotifyFetcher{albumsByArtist: map[string][]catalog.Release{
+		"noise-artist": {
+			{SpotifyID: "album-1", Name: "Noise Album", ReleaseDate: "2020-01-01"},
+		},
+	}}
+	searcher := artists.NewAlbumEvidenceCandidateSearcher(
+		fixedCandidateSearcher{candidates: []catalog.ArtistCandidate{
+			{Name: "Completely Unrelated Orchestra", SpotifyID: "noise-artist", Genres: []string{"classical"}},
+		}},
+		spotify,
+		albumAuditMusicBrainzSearcher{releaseGroups: []artists.MusicBrainzReleaseGroup{
+			{ID: "mb-1", Title: "Expected Album", FirstReleaseDate: "1998"},
+		}},
+	)
+
+	candidates, err := searcher.SearchArtistCandidates(context.Background(), catalog.Artist{Name: "Killarmy"})
+
+	require.NoError(t, err)
+	require.Empty(t, candidates)
+	require.Empty(t, spotify.requestedIDs)
 }
 
 func TestAlbumEvidenceCandidateSearcherKeepsCandidatesWhenMusicBrainzFails(t *testing.T) {
@@ -97,4 +191,37 @@ func TestAlbumEvidenceCandidateSearcherKeepsCandidatesWhenMusicBrainzHasNoAlbums
 	require.NoError(t, err)
 	require.Equal(t, []catalog.ArtistCandidate{{Name: "Unknown", SpotifyID: "artist-1"}}, candidates)
 	require.Empty(t, spotify.requestedIDs)
+}
+
+func TestAlbumEvidenceCandidateSearcherWarnsWhenConfiguredSpotifyIDHasNoMusicBrainzAlbumMatches(t *testing.T) {
+	spotify := &albumAuditSpotifyFetcher{albumsByArtist: map[string][]catalog.Release{
+		"good-artist": {
+			{SpotifyID: "album-1", Name: "Enter the Wu-Tang (36 Chambers)", ReleaseDate: "1993-11-09"},
+		},
+		"bad-artist": {
+			{SpotifyID: "album-2", Name: "Unrelated Album", ReleaseDate: "2020-01-01"},
+		},
+	}}
+	searcher := artists.NewAlbumEvidenceCandidateSearcher(
+		fixedCandidateSearcher{},
+		spotify,
+		albumAuditMusicBrainzSearcher{releaseGroups: []artists.MusicBrainzReleaseGroup{
+			{ID: "mb-1", Title: "Enter the Wu-Tang (36 Chambers)", FirstReleaseDate: "1993-11-09"},
+		}},
+	)
+
+	warnings, err := searcher.ReviewConfiguredSpotifyIDs(context.Background(), catalog.Artist{
+		Name:       "Wu-Tang Clan",
+		SpotifyID:  "good-artist",
+		SpotifyIDs: []string{"bad-artist"},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, warnings, 1)
+	require.Equal(t, "bad-artist", warnings[0].SpotifyID)
+	require.Contains(t, warnings[0].Reason, "no Spotify albums matched")
+	require.Equal(t, 1, warnings[0].SpotifyAlbumCount)
+	require.Equal(t, 1, warnings[0].MusicBrainzAlbumCount)
+	require.Equal(t, "Unrelated Album", warnings[0].SpotifyAlbums[0].Title)
+	require.Equal(t, []string{"good-artist", "bad-artist"}, spotify.requestedIDs)
 }

--- a/internal/application/artists/resolve.go
+++ b/internal/application/artists/resolve.go
@@ -14,6 +14,10 @@ type CandidateSearcher interface {
 	SearchArtistCandidates(context.Context, catalog.Artist) ([]catalog.ArtistCandidate, error)
 }
 
+type CatalogAwareCandidateSearcher interface {
+	SearchArtistCandidatesWithCatalog(context.Context, catalog.Artist, catalog.EditorialCatalog) ([]catalog.ArtistCandidate, error)
+}
+
 type ResolveArtists struct {
 	store    CatalogStore
 	searcher CandidateSearcher
@@ -148,7 +152,7 @@ func (r ResolveArtists) resolve(ctx context.Context, c catalog.EditorialCatalog,
 		event := ResolveProgress{Stage: "artist_started", ArtistSlug: artist.Slug, ArtistName: artist.Name, ArtistIndex: index + 1, ArtistTotal: len(artistsToResolve)}
 		emitResolveProgress(progress, event)
 
-		candidates, err := r.searcher.SearchArtistCandidates(ctx, artist)
+		candidates, err := searchArtistCandidates(ctx, r.searcher, artist, c)
 		if err != nil {
 			report.Errors = append(report.Errors, ResolveError{Slug: artist.Slug, Err: err})
 			event.Stage = "artist_failed"
@@ -171,6 +175,13 @@ func (r ResolveArtists) resolve(ctx context.Context, c catalog.EditorialCatalog,
 	})
 
 	return report, nil
+}
+
+func searchArtistCandidates(ctx context.Context, searcher CandidateSearcher, artist catalog.Artist, c catalog.EditorialCatalog) ([]catalog.ArtistCandidate, error) {
+	if contextual, ok := searcher.(CatalogAwareCandidateSearcher); ok {
+		return contextual.SearchArtistCandidatesWithCatalog(ctx, artist, c)
+	}
+	return searcher.SearchArtistCandidates(ctx, artist)
 }
 
 func unresolvedArtists(artists []catalog.Artist) []catalog.Artist {

--- a/internal/application/artists/spotify_cache.go
+++ b/internal/application/artists/spotify_cache.go
@@ -1,0 +1,52 @@
+package artists
+
+import (
+	"context"
+	"errors"
+
+	"github.com/javiyt/spotwufamily/internal/domain/catalog"
+)
+
+var ErrCacheMiss = errors.New("artist Spotify cache miss")
+
+type SpotifyAlbumCache interface {
+	GetCachedArtistAlbums(context.Context, string, []string) ([]catalog.Release, error)
+	GetCachedAlbumTracks(context.Context, string) ([]catalog.Track, error)
+}
+
+type CachedSpotifyAlbumFetcher struct {
+	cache  SpotifyAlbumCache
+	remote spotifyAlbumTrackFetcher
+}
+
+func NewCachedSpotifyAlbumFetcher(cache SpotifyAlbumCache, remote spotifyAlbumTrackFetcher) CachedSpotifyAlbumFetcher {
+	return CachedSpotifyAlbumFetcher{cache: cache, remote: remote}
+}
+
+func (f CachedSpotifyAlbumFetcher) GetArtistAlbums(ctx context.Context, spotifyID string, groups []string) ([]catalog.Release, error) {
+	if f.cache != nil {
+		releases, err := f.cache.GetCachedArtistAlbums(ctx, spotifyID, groups)
+		if err == nil {
+			return releases, nil
+		}
+		if !errors.Is(err, ErrCacheMiss) {
+			return nil, err
+		}
+	}
+
+	return f.remote.GetArtistAlbums(ctx, spotifyID, groups)
+}
+
+func (f CachedSpotifyAlbumFetcher) GetAlbumTracks(ctx context.Context, spotifyID string) ([]catalog.Track, error) {
+	if f.cache != nil {
+		tracks, err := f.cache.GetCachedAlbumTracks(ctx, spotifyID)
+		if err == nil {
+			return tracks, nil
+		}
+		if !errors.Is(err, ErrCacheMiss) {
+			return nil, err
+		}
+	}
+
+	return f.remote.GetAlbumTracks(ctx, spotifyID)
+}

--- a/internal/application/artists/spotify_cache_test.go
+++ b/internal/application/artists/spotify_cache_test.go
@@ -1,0 +1,76 @@
+package artists_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javiyt/spotwufamily/internal/application/artists"
+	"github.com/javiyt/spotwufamily/internal/domain/catalog"
+	"github.com/stretchr/testify/require"
+)
+
+type fixedSpotifyAlbumCache struct {
+	albums []catalog.Release
+	tracks []catalog.Track
+	err    error
+}
+
+func (c fixedSpotifyAlbumCache) GetCachedArtistAlbums(context.Context, string, []string) ([]catalog.Release, error) {
+	return c.albums, c.err
+}
+
+func (c fixedSpotifyAlbumCache) GetCachedAlbumTracks(context.Context, string) ([]catalog.Track, error) {
+	return c.tracks, c.err
+}
+
+type countingRemoteSpotifyFetcher struct {
+	albumCalls int
+	trackCalls int
+}
+
+func (f *countingRemoteSpotifyFetcher) GetArtistAlbums(context.Context, string, []string) ([]catalog.Release, error) {
+	f.albumCalls++
+	return []catalog.Release{{SpotifyID: "remote-album"}}, nil
+}
+
+func (f *countingRemoteSpotifyFetcher) GetAlbumTracks(context.Context, string) ([]catalog.Track, error) {
+	f.trackCalls++
+	return []catalog.Track{{SpotifyID: "remote-track"}}, nil
+}
+
+func TestCachedSpotifyAlbumFetcherUsesCacheBeforeRemote(t *testing.T) {
+	remote := &countingRemoteSpotifyFetcher{}
+	fetcher := artists.NewCachedSpotifyAlbumFetcher(
+		fixedSpotifyAlbumCache{
+			albums: []catalog.Release{{SpotifyID: "cached-album"}},
+			tracks: []catalog.Track{{SpotifyID: "cached-track"}},
+		},
+		remote,
+	)
+
+	albums, err := fetcher.GetArtistAlbums(context.Background(), "artist-1", []string{"album"})
+	require.NoError(t, err)
+	require.Equal(t, "cached-album", albums[0].SpotifyID)
+	tracks, err := fetcher.GetAlbumTracks(context.Background(), "album-1")
+	require.NoError(t, err)
+	require.Equal(t, "cached-track", tracks[0].SpotifyID)
+	require.Zero(t, remote.albumCalls)
+	require.Zero(t, remote.trackCalls)
+}
+
+func TestCachedSpotifyAlbumFetcherFallsBackOnCacheMiss(t *testing.T) {
+	remote := &countingRemoteSpotifyFetcher{}
+	fetcher := artists.NewCachedSpotifyAlbumFetcher(
+		fixedSpotifyAlbumCache{err: artists.ErrCacheMiss},
+		remote,
+	)
+
+	albums, err := fetcher.GetArtistAlbums(context.Background(), "artist-1", []string{"album"})
+	require.NoError(t, err)
+	require.Equal(t, "remote-album", albums[0].SpotifyID)
+	tracks, err := fetcher.GetAlbumTracks(context.Background(), "album-1")
+	require.NoError(t, err)
+	require.Equal(t, "remote-track", tracks[0].SpotifyID)
+	require.Equal(t, 1, remote.albumCalls)
+	require.Equal(t, 1, remote.trackCalls)
+}

--- a/internal/application/catalogsync/sync.go
+++ b/internal/application/catalogsync/sync.go
@@ -3,6 +3,7 @@ package catalogsync
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -214,6 +215,7 @@ func (s SyncCatalog) Run(ctx context.Context, options Options) (Report, error) {
 	report.RunID = runID
 	progress(options.Progress, ProgressEvent{Stage: ProgressRunStarted, RunID: runID})
 
+	var abortErr error
 	for index, configuredArtist := range artists {
 		event := ProgressEvent{
 			Stage:       ProgressArtistStarted,
@@ -230,6 +232,10 @@ func (s SyncCatalog) Run(ctx context.Context, options Options) (Report, error) {
 			event.Stage = ProgressArtistFailed
 			event.Err = err
 			progress(options.Progress, event)
+			if shouldAbortSync(err) {
+				abortErr = err
+				break
+			}
 			continue
 		}
 		if err := s.repository.SaveArtistSyncCheckpoint(ctx, runID, configuredArtist, "completed", artistStats, s.clock.Now()); err != nil {
@@ -258,6 +264,9 @@ func (s SyncCatalog) Run(ctx context.Context, options Options) (Report, error) {
 	}
 	progress(options.Progress, ProgressEvent{Stage: ProgressRunFinished, RunID: runID, Stats: report.Stats})
 
+	if abortErr != nil {
+		return report, fmt.Errorf("sync aborted after Spotify rate limit; progress saved as partial run: %w", abortErr)
+	}
 	if report.ArtistsFailed > 0 {
 		return report, fmt.Errorf("%d artist syncs failed", report.ArtistsFailed)
 	}
@@ -335,6 +344,25 @@ func progress(progressFunc func(ProgressEvent), event ProgressEvent) {
 	if progressFunc != nil {
 		progressFunc(event)
 	}
+}
+
+type syncAborter interface {
+	AbortSync() bool
+}
+
+func shouldAbortSync(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var aborter syncAborter
+	if errors.As(err, &aborter) && aborter.AbortSync() {
+		return true
+	}
+
+	message := strings.ToUpper(err.Error())
+	return strings.Contains(message, "QUOTA_EXCEEDED") ||
+		strings.Contains(message, "SPOTIFY REQUESTED RETRY AFTER") && strings.Contains(message, "ABOVE MAX WAIT")
 }
 
 func enabledArtists(artists []catalog.Artist, slug string) []catalog.Artist {

--- a/internal/application/catalogsync/sync_test.go
+++ b/internal/application/catalogsync/sync_test.go
@@ -179,6 +179,35 @@ func TestSyncCatalogReturnsPartialFailure(t *testing.T) {
 	require.Len(t, report.Errors, 1)
 }
 
+func TestSyncCatalogAbortsAfterSpotifyQuotaExceeded(t *testing.T) {
+	store := fakeStore{catalog: catalog.EditorialCatalog{
+		Version: 1,
+		Artists: []catalog.Artist{
+			enabledArtist("wu-tang-clan", "34EP7KEpOjXcM2TCat1ISk"),
+			func() catalog.Artist {
+				artist := enabledArtist("gravediggaz", "0CH4f9m2L3TRaA5oErU2p0")
+				artist.Name = "Gravediggaz"
+				return artist
+			}(),
+		},
+	}}
+	fetcher := &fakeFetcher{
+		artist:    catalog.ArtistCandidate{Name: "Wu-Tang Clan", SpotifyID: "34EP7KEpOjXcM2TCat1ISk"},
+		albumsErr: fakeAbortError{err: errors.New("temporary Spotify error: Spotify quota exceeded: QUOTA_EXCEEDED")},
+	}
+	repository := &fakeRepository{}
+	usecase := catalogsync.NewSyncCatalog(store, fetcher, repository, fixedClock{})
+
+	report, err := usecase.Run(context.Background(), catalogsync.Options{CatalogPath: "ignored"})
+
+	require.ErrorContains(t, err, "sync aborted after Spotify rate limit")
+	require.Equal(t, 1, report.ArtistsFailed)
+	require.Zero(t, report.ArtistsProcessed)
+	require.Equal(t, []string{"34EP7KEpOjXcM2TCat1ISk"}, fetcher.artistIDs)
+	require.Equal(t, "partial", repository.finishedStatus)
+	require.Len(t, report.Errors, 1)
+}
+
 func requireProgressStages(t *testing.T, events []catalogsync.ProgressEvent, stages ...catalogsync.ProgressStage) {
 	t.Helper()
 
@@ -199,6 +228,7 @@ func (f fakeStore) Load(context.Context, string) (catalog.EditorialCatalog, erro
 type fakeFetcher struct {
 	artist    catalog.ArtistCandidate
 	releases  []catalog.Release
+	albumsErr error
 	albums    map[string]catalog.Release
 	tracks    map[string][]catalog.Track
 	groups    []string
@@ -217,6 +247,9 @@ func (f *fakeFetcher) GetArtist(_ context.Context, spotifyID string) (catalog.Ar
 
 func (f *fakeFetcher) GetArtistAlbums(_ context.Context, _ string, groups []string) ([]catalog.Release, error) {
 	f.groups = append([]string(nil), groups...)
+	if f.albumsErr != nil {
+		return nil, f.albumsErr
+	}
 	return f.releases, nil
 }
 
@@ -233,6 +266,7 @@ type fakeRepository struct {
 	savedReleases       []catalog.ReleaseTracks
 	resumableRun        catalogsync.ResumableSyncRun
 	checkpointedArtists []string
+	finishedStatus      string
 }
 
 func (f *fakeRepository) SaveConfiguredArtists(context.Context, []catalog.Artist) error {
@@ -247,7 +281,8 @@ func (f *fakeRepository) FindResumableSyncRun(context.Context, catalogsync.SyncR
 	return f.resumableRun, f.resumableRun.ID > 0, nil
 }
 
-func (f *fakeRepository) FinishSyncRun(context.Context, int64, string, catalogsync.SyncStats) error {
+func (f *fakeRepository) FinishSyncRun(_ context.Context, _ int64, status string, _ catalogsync.SyncStats) error {
+	f.finishedStatus = status
 	return nil
 }
 
@@ -279,4 +314,20 @@ func enabledArtist(slug, spotifyID string) catalog.Artist {
 		Roles:     []catalog.Category{catalog.CategoryCore},
 		Enabled:   true,
 	}
+}
+
+type fakeAbortError struct {
+	err error
+}
+
+func (e fakeAbortError) Error() string {
+	return e.err.Error()
+}
+
+func (e fakeAbortError) Unwrap() error {
+	return e.err
+}
+
+func (e fakeAbortError) AbortSync() bool {
+	return true
 }

--- a/internal/domain/catalog/resolve.go
+++ b/internal/domain/catalog/resolve.go
@@ -3,14 +3,15 @@ package catalog
 import "strings"
 
 type ArtistCandidate struct {
-	Name       string   `json:"name"`
-	SpotifyID  string   `json:"spotify_id"`
-	URL        string   `json:"url"`
-	ImageURL   string   `json:"image_url"`
-	Images     []Image  `json:"images,omitempty"`
-	Popularity int      `json:"popularity"`
-	Followers  int      `json:"followers"`
-	Genres     []string `json:"genres"`
+	Name                  string   `json:"name"`
+	SpotifyID             string   `json:"spotify_id"`
+	URL                   string   `json:"url"`
+	ImageURL              string   `json:"image_url"`
+	Images                []Image  `json:"images,omitempty"`
+	Popularity            int      `json:"popularity"`
+	Followers             int      `json:"followers"`
+	Genres                []string `json:"genres"`
+	RelatedArtistEvidence []string `json:"related_artist_evidence,omitempty"`
 }
 
 type CandidateMatch struct {
@@ -34,13 +35,26 @@ func RankCandidates(artist Artist, candidates []ArtistCandidate) []CandidateMatc
 
 	for i := 0; i < len(matches); i++ {
 		for j := i + 1; j < len(matches); j++ {
-			if matches[j].Score > matches[i].Score {
+			if candidateMatchLess(matches[i], matches[j]) {
 				matches[i], matches[j] = matches[j], matches[i]
 			}
 		}
 	}
 
 	return matches
+}
+
+func candidateMatchLess(left, right CandidateMatch) bool {
+	if left.Score != right.Score {
+		return left.Score < right.Score
+	}
+	if len(left.Candidate.RelatedArtistEvidence) != len(right.Candidate.RelatedArtistEvidence) {
+		return len(left.Candidate.RelatedArtistEvidence) < len(right.Candidate.RelatedArtistEvidence)
+	}
+	if left.Candidate.Popularity != right.Candidate.Popularity {
+		return left.Candidate.Popularity < right.Candidate.Popularity
+	}
+	return left.Candidate.Followers < right.Candidate.Followers
 }
 
 func scoreCandidate(artist Artist, candidate ArtistCandidate) (int, string) {
@@ -87,7 +101,7 @@ func scoreCandidate(artist Artist, candidate ArtistCandidate) (int, string) {
 
 func applyGenreEvidence(score int, reason string, artist Artist, candidate ArtistCandidate) (int, string) {
 	if len(candidate.Genres) == 0 {
-		return score, reason
+		return applyRelatedArtistEvidence(score, reason, candidate)
 	}
 	if len(artist.Genres) > 0 {
 		if genresCompatible(artist.Genres, candidate.Genres) {
@@ -97,13 +111,13 @@ func applyGenreEvidence(score int, reason string, artist Artist, candidate Artis
 					score = 94
 				}
 			}
-			return score, reason + " + similar genre evidence"
+			return applyRelatedArtistEvidence(score, reason+" + similar genre evidence", candidate)
 		}
 		score -= 20
 		if score < 0 {
 			score = 0
 		}
-		return score, reason + " - incompatible genre evidence"
+		return applyRelatedArtistEvidence(score, reason+" - incompatible genre evidence", candidate)
 	}
 	if hasHipHopGenre(candidate.Genres) {
 		if score < 95 {
@@ -112,14 +126,25 @@ func applyGenreEvidence(score int, reason string, artist Artist, candidate Artis
 				score = 94
 			}
 		}
-		return score, reason + " + hip-hop genre evidence"
+		return applyRelatedArtistEvidence(score, reason+" + hip-hop genre evidence", candidate)
 	}
 
 	score -= 10
 	if score < 0 {
 		score = 0
 	}
-	return score, reason + " - non hip-hop genre evidence"
+	return applyRelatedArtistEvidence(score, reason+" - non hip-hop genre evidence", candidate)
+}
+
+func applyRelatedArtistEvidence(score int, reason string, candidate ArtistCandidate) (int, string) {
+	if len(candidate.RelatedArtistEvidence) == 0 {
+		return score, reason
+	}
+	score += 15
+	if score > 100 {
+		score = 100
+	}
+	return score, reason + " + track credit evidence"
 }
 
 func genresCompatible(expected, actual []string) bool {

--- a/internal/domain/catalog/resolve_test.go
+++ b/internal/domain/catalog/resolve_test.go
@@ -67,3 +67,23 @@ func TestRankCandidatesUsesStoredArtistGenresForCompatibility(t *testing.T) {
 	require.Equal(t, 80, matches[1].Score)
 	require.Contains(t, matches[1].Reason, "incompatible genre evidence")
 }
+
+func TestRankCandidatesBoostsTrackCreditEvidence(t *testing.T) {
+	matches := catalog.RankCandidates(catalog.Artist{Name: "Solomon Childs"}, []catalog.ArtistCandidate{
+		{Name: "Solomon Childs Legacy"},
+		{Name: "Solomon Childs Crew", RelatedArtistEvidence: []string{"credited on Wu-Tang Clan track"}},
+	})
+
+	require.Equal(t, "Solomon Childs Crew", matches[0].Candidate.Name)
+	require.Greater(t, matches[0].Score, matches[1].Score)
+	require.Contains(t, matches[0].Reason, "track credit evidence")
+}
+
+func TestRankCandidatesUsesSpotifyPopularityAndFollowersAsTieBreakers(t *testing.T) {
+	matches := catalog.RankCandidates(catalog.Artist{Name: "Killarmy"}, []catalog.ArtistCandidate{
+		{Name: "Killarmy", SpotifyID: "low", Popularity: 10, Followers: 100},
+		{Name: "Killarmy", SpotifyID: "high", Popularity: 20, Followers: 50},
+	})
+
+	require.Equal(t, "high", matches[0].Candidate.SpotifyID)
+}


### PR DESCRIPTION
This commit refactors the Spotify artist resolution process to incorporate database usage and enhances documentation for better clarity.

The following changes were made:
- **Makefile updates**: `artists-resolve-report`, `artists-resolve-apply`, `artists-resolve-interactive`, and `artists-review-interactive` targets now pass the `--db` argument to the CLI, ensuring that the database is utilized for these operations.
- **README.md updates**:
    - Added a note that interactive review warns about configured Spotify IDs with no album matches against MusicBrainz.
    - Updated the description of live Spotify artist resolution to clarify its use of MusicBrainz album evidence, scoring boosts for track-credited candidates, and the benefits of reading cached albums/tracks from SQLite.
- **docs/musicbrainz.md updates**: Clarified how Spotify artist resolution uses MusicBrainz as album evidence, including the exception for track-credit evidence and the caching behavior for album and track lookups.
- **docs/operations.md updates**: Added a note about MusicBrainz warnings during interactive review when configured Spotify albums don't match known MusicBrainz release groups.

These changes enhance the accuracy and efficiency of Spotify artist resolution by leveraging cached data and providing more comprehensive feedback during interactive review.
