### PR TITLE
feat: Add artist aliases and filtering functionality

### DIFF
--- a/data/artists.yaml
+++ b/data/artists.yaml
@@ -46,7 +46,8 @@ artists:
     category: affiliate_group
     roles:
       - affiliate_group
-    aliases: []
+    aliases:
+      - 1.4.0 Productions
     enabled: true
     editorial_order: 3
     notes: ""
@@ -131,7 +132,8 @@ artists:
     category: affiliate_group
     roles:
       - affiliate_group
-    aliases: []
+    aliases:
+      - Brooklyn Zoo
     enabled: false
     editorial_order: 10
     notes: ""
@@ -182,7 +184,8 @@ artists:
     category: affiliate_group
     roles:
       - affiliate_group
-    aliases: []
+    aliases:
+      - G.P. Wu
     enabled: true
     editorial_order: 14
     notes: ""
@@ -235,7 +238,8 @@ artists:
     category: affiliate_group
     roles:
       - affiliate_group
-    aliases: []
+    aliases:
+      - Housegang
     enabled: false
     editorial_order: 18
     notes: ""
@@ -255,7 +259,8 @@ artists:
     category: affiliate_group
     roles:
       - affiliate_group
-    aliases: []
+    aliases:
+      - Klik Ga Bow
     enabled: false
     editorial_order: 20
     notes: ""
@@ -290,7 +295,8 @@ artists:
     category: affiliate_group
     roles:
       - affiliate_group
-    aliases: []
+    aliases:
+      - Money Makin Operation
     enabled: true
     editorial_order: 23
     notes: ""
@@ -301,7 +307,8 @@ artists:
     category: affiliate_group
     roles:
       - affiliate_group
-    aliases: []
+    aliases:
+      - North Star
     enabled: true
     editorial_order: 24
     notes: ""
@@ -404,7 +411,8 @@ artists:
     category: affiliate_group
     roles:
       - affiliate_group
-    aliases: []
+    aliases:
+      - TMF
     enabled: true
     editorial_order: 32
     notes: ""
@@ -415,7 +423,9 @@ artists:
     category: affiliate_group
     roles:
       - affiliate_group
-    aliases: []
+    aliases:
+      - Two Da Road
+      - 2 On Da Road
     enabled: false
     editorial_order: 33
     notes: ""
@@ -425,7 +435,8 @@ artists:
     category: affiliate_group
     roles:
       - affiliate_group
-    aliases: []
+    aliases:
+      - Universal Zu Studios
     enabled: true
     editorial_order: 34
     notes: ""
@@ -1439,3 +1450,912 @@ artists:
     notes: ""
     external_url: https://open.spotify.com/artist/5eGENdlc6kQZeuzUJZ4W8B
     image_url: https://i.scdn.co/image/ab6761610000e5eb6d7a970acc57f827bfaf44f6
+  - slug: chey
+    name: CHEY
+    spotify_id: ""
+    category: affiliate_artist
+    roles:
+      - affiliate_artist
+    aliases: []
+    enabled: false
+    editorial_order: 111
+    notes: Discovered from Wikipedia (Rappers); review before enabling.
+    external_url: https://en.wikipedia.org/wiki/List%20of%20Wu-Tang%20Clan%20affiliates#CHEY
+  - slug: d1c3
+    name: D1C3
+    spotify_id: ""
+    category: affiliate_artist
+    roles:
+      - affiliate_artist
+    aliases: []
+    enabled: false
+    editorial_order: 112
+    notes: Discovered from Wikipedia (Rappers); review before enabling.
+    external_url: https://en.wikipedia.org/wiki/List%20of%20Wu-Tang%20Clan%20affiliates#D1C3
+  - slug: pxwer
+    name: PXWER
+    spotify_id: ""
+    category: affiliate_artist
+    roles:
+      - affiliate_artist
+    aliases: []
+    enabled: false
+    editorial_order: 113
+    notes: Discovered from Wikipedia (Rappers); review before enabling.
+    external_url: https://en.wikipedia.org/wiki/List%20of%20Wu-Tang%20Clan%20affiliates#PXWER
+  - slug: dirty-clanzmen
+    name: Dirty Clanzmen
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 114
+    notes: Discovered from Wikipedia (Groups); review before enabling.
+    external_url: https://en.wikipedia.org/wiki/List%20of%20Wu-Tang%20Clan%20affiliates#Dirty_Clanzmen
+  - slug: othorized-f-a-m
+    name: Othorized F.A.M.
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 115
+    notes: Discovered from Wikipedia (Groups); review before enabling.
+    external_url: https://en.wikipedia.org/wiki/List%20of%20Wu-Tang%20Clan%20affiliates#Othorized_F.A.M.
+  - slug: deejay-khalil
+    name: Deejay Khalil
+    spotify_id: ""
+    category: collaborator
+    roles:
+      - collaborator
+    aliases: []
+    enabled: false
+    editorial_order: 116
+    notes: Discovered from Wikipedia (DJs); review before enabling.
+    external_url: https://en.wikipedia.org/wiki/List%20of%20Wu-Tang%20Clan%20affiliates#Deejay_Khalil
+  - slug: nary-da-producer
+    name: Nary Da Producer
+    spotify_id: ""
+    category: producer
+    roles:
+      - producer
+    aliases: []
+    enabled: false
+    editorial_order: 117
+    notes: Discovered from Wikipedia (Producers); review before enabling.
+    external_url: https://en.wikipedia.org/wiki/List%20of%20Wu-Tang%20Clan%20affiliates#Nary_Da_Producer
+  - slug: method-man
+    name: Method Man
+    spotify_id: 4VmEWwd8y9MCLwexFMdpwt
+    category: core
+    roles:
+      - core
+    aliases:
+      - Meth
+      - Tical
+      - Johnny Blaze
+    enabled: true
+    editorial_order: 118
+    notes: Core Wu-Tang Clan member added from existing local Spotify credits.
+    external_url: https://open.spotify.com/artist/4VmEWwd8y9MCLwexFMdpwt
+  - slug: method-man-redman
+    name: Method Man & Redman
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+      - collaborator
+    aliases:
+      - Method Man and Redman
+      - Meth & Red
+    enabled: false
+    editorial_order: 119
+    notes: Added as editorial placeholder; resolve Spotify ID before enabling.
+  - slug: 2nd-generation-wu
+    name: 2nd Generation Wu
+    spotify_id: 176ThSTKVe29Uxsae3mkUw
+    spotify_ids:
+      - 4YFhRkKcHSle87kcLc8RIy
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 120
+    notes: Candidate from online Wu-Tang affiliate groups audit; local Spotify credit candidate present; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: 71raw
+    name: 71Raw
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 121
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: a-c-g-137
+    name: A.C.G. 137
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 122
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: actual-facts
+    name: Actual Facts
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 123
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: the-almighty
+    name: The Almighty
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 124
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: american-poets-2099
+    name: American Poets 2099
+    spotify_id: 5qEjOQbO7okscrhr11skN5
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 125
+    notes: Candidate from online Wu-Tang affiliate groups audit; local Spotify credit candidate present; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: ancients-coins
+    name: Ancients Coins
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 126
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: a-r
+    name: "A & R"
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 127
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: armor-of-god
+    name: Armor of God
+    spotify_id: 5024w0wkcfyY5GSSHwfbol
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 128
+    notes: Candidate from online Wu-Tang affiliate groups audit; local Spotify credit candidate present; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: babylon-warchild
+    name: Babylon Warchild
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 129
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: black-knights-of-the-north-star
+    name: Black Knights of the North Star
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 130
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: black-lotus
+    name: Black Lotus
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 131
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: black-rose-kartel
+    name: Black Rose Kartel
+    spotify_id: 7eT746L8wPurjMaBSwCbZz
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 132
+    notes: Candidate from online Wu-Tang affiliate groups audit; local Spotify credit candidate present; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: black-techs
+    name: Black Techs
+    spotify_id: 3IjXvDtFJeKWMvbE2VFeM3
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 133
+    notes: Candidate from online Wu-Tang affiliate groups audit; local Spotify credit candidate present; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: black-w-a-s-p
+    name: Black W.A.S.P.
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 134
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: the-blaquesmiths
+    name: The Blaquesmiths
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 135
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: celestial-souljahz
+    name: Celestial Souljahz
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 136
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: c-i-a
+    name: C.I.A.
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 137
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: coney-island-gankstas
+    name: Coney Island Gankstas
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 138
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: crooks-of-da-round-table
+    name: Crooks of Da Round Table
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 139
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: czarface
+    name: CZARFACE
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 140
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: da-groove-stalkers
+    name: Da Groove Stalkers
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 141
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: da-last-future
+    name: Da Last Future
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 142
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: da-monstar-mob
+    name: Da Monstar Mob
+    spotify_id: 4dNBxqrQ0jymdRQen1CONu
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 143
+    notes: Candidate from online Wu-Tang affiliate groups audit; local Spotify credit candidate present; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: da-undadogz
+    name: Da Undadogz
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 144
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: disciples-of-armageddon
+    name: Disciples of Armageddon
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 145
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: dmd-posse
+    name: DMD Posse
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 146
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: d-r-u-g-g
+    name: D.R.U.G.G.
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 147
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: the-four-horsemen
+    name: The Four Horsemen
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 148
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: g-ciples
+    name: G-Ciples
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 149
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: ghetto-government-officialz
+    name: Ghetto Government Officialz
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 150
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: goldminerz
+    name: GoldMinerz
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 151
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: green-back-gorillas
+    name: Green Back Gorillas
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 152
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: gunslingaz
+    name: Gunslingaz
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 153
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: hawk-kryme
+    name: "Hawk & Kryme"
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 154
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: heart-foundation
+    name: Heart Foundation
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 155
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: henchmen
+    name: Henchmen
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 156
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: hidden-aspects
+    name: Hidden Aspects
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 157
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: homicidal-committee
+    name: Homicidal Committee
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 158
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: the-indovizualz
+    name: The Indovizualz
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 159
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: iron-empire
+    name: Iron Empire
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 160
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: k-m-g
+    name: K.M.G.
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 161
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: lin-brotherz
+    name: Lin Brotherz
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 162
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: loyal-n-lazlo
+    name: Loyal-N-Lazlo
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 163
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: mafioso-chapter
+    name: Mafioso Chapter
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 164
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: moon-crickets
+    name: Moon Crickets
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 165
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: most-high-brotherz
+    name: Most High Brotherz
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 166
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: mysterious
+    name: Mysterious
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 167
+    notes: Candidate from online Wu-Tang affiliate groups audit; local Spotify credit match is ambiguous; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: the-odd-couple
+    name: The Odd Couple
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 168
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: premium-plus
+    name: Premium Plus
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 169
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: rocks-the-world-productions
+    name: Rocks the World Productions
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 170
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: ruthless-bastards
+    name: Ruthless Bastards
+    spotify_id: 08HoctQX4mOLnlvNfoM80E
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 171
+    notes: Candidate from online Wu-Tang affiliate groups audit; local Spotify credit candidate present; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: sahara
+    name: Sahara
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 172
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: the-sentinels
+    name: The Sentinels
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 173
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: shadow-clan-productions
+    name: Shadow Clan Productions
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 174
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: shadow-government
+    name: Shadow Government
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 175
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: shaolin-soldiers
+    name: Shaolin Soldiers
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 176
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: the-shield-enforcers
+    name: The Shield Enforcers
+    spotify_id: 1LbdcQlYwhordhevATZ4Gr
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 177
+    notes: Candidate from online Wu-Tang affiliate groups audit; local Spotify credit candidate present; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: sonz-of-wu
+    name: Sonz of Wu
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 178
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: soul-kid-klik
+    name: Soul Kid Klik
+    spotify_id: 3Q6VsjaMQSNzKbHL29Fkul
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 179
+    notes: Candidate from online Wu-Tang affiliate groups audit; local Spotify credit candidate present; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: staten-stars
+    name: Staten Stars
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 180
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: the-strength
+    name: The Strength
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 181
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: team-napalm
+    name: Team Napalm
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 182
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: t-h-u-g-angelz
+    name: T.H.U.G. Angelz
+    spotify_id: 3c3NOwaGMMYnH8lRGvnEEi
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 183
+    notes: Candidate from online Wu-Tang affiliate groups audit; local Spotify credit candidate present; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: thug-vatican
+    name: Thug Vatican
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 184
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: tru-n-livin
+    name: Tru-N-Livin
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 185
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: two-4-war
+    name: Two 4 War
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 186
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: united-kingdom
+    name: United Kingdom
+    spotify_id: 3grYksp0csNBBSKDp1azcq
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 187
+    notes: Candidate from online Wu-Tang affiliate groups audit; local Spotify credit candidate present; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: west-coast-killa-beez
+    name: West Coast Killa Beez
+    spotify_id: 507DEVGD42PYBbxaMscxd2
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 188
+    notes: Candidate from online Wu-Tang affiliate groups audit; local Spotify credit candidate present; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: wisemen
+    name: Wisemen
+    spotify_id: 4E19oAZ49FFJmhQ3KCwhrU
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 189
+    notes: Candidate from online Wu-Tang affiliate groups audit; local Spotify credit candidate present; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: wu-block
+    name: Wu Block
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 190
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: wu-elements
+    name: Wu Elements
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 191
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/
+  - slug: wu-latino
+    name: Wu-Latino
+    spotify_id: ""
+    category: affiliate_group
+    roles:
+      - affiliate_group
+    aliases: []
+    enabled: false
+    editorial_order: 192
+    notes: Candidate from online Wu-Tang affiliate groups audit; review before enabling.
+    external_url: https://www.rapreviews.com/2021/09/enter-the-wu-tang-affiliates-107-chambers/

--- a/internal/adapters/outbound/sqlite/database_test.go
+++ b/internal/adapters/outbound/sqlite/database_test.go
@@ -269,6 +269,7 @@ func TestSaveArtistCatalogPersistsNormalizedCatalog(t *testing.T) {
 	require.Len(t, exported.Tracks, 1)
 	require.Equal(t, "Wu-Tang Clan", exported.Artists[0].Name)
 	require.Equal(t, "Album One", exported.Albums[0].Name)
+	require.Equal(t, "wu-tang-clan", exported.Albums[0].Related[0].Slug)
 	require.Equal(t, "Track One", exported.Albums[0].Tracks[0].Name)
 	require.Equal(t, "Wu-Tang Clan", exported.Tracks[0].Artists[0].Name)
 }

--- a/internal/adapters/outbound/sqlite/export_reader.go
+++ b/internal/adapters/outbound/sqlite/export_reader.go
@@ -26,6 +26,10 @@ func (d *Database) LoadExportCatalog(ctx context.Context) (catalogexport.Catalog
 	if err != nil {
 		return catalogexport.Catalog{}, err
 	}
+	albumRelatedArtists, err := d.albumRelatedArtists(ctx)
+	if err != nil {
+		return catalogexport.Catalog{}, err
+	}
 	trackArtists, err := d.trackCredits(ctx)
 	if err != nil {
 		return catalogexport.Catalog{}, err
@@ -45,6 +49,7 @@ func (d *Database) LoadExportCatalog(ctx context.Context) (catalogexport.Catalog
 
 	for index := range albums {
 		albums[index].Artists = albumArtists[albums[index].SpotifyID]
+		albums[index].Related = albumRelatedArtists[albums[index].SpotifyID]
 		albums[index].Tracks = albumTracks[albums[index].SpotifyID]
 		albums[index].Copyrights = copyrights[albums[index].SpotifyID]
 	}
@@ -82,13 +87,44 @@ SELECT
   COALESCE(ca.editorial_order, 0),
   COALESCE(eu.url, ''),
   COALESCE(img.url, ''),
-  COUNT(DISTINCT aa.album_id),
-  COUNT(DISTINCT at.track_id)
+  (
+    SELECT COUNT(DISTINCT album_id)
+    FROM (
+      SELECT aa.album_id
+      FROM artist_albums aa
+      WHERE aa.configured_artist_slug = ca.slug AND aa.active = 1
+      UNION
+      SELECT aa2.album_id
+      FROM album_artists aa2
+      JOIN configured_artist_spotify_ids casi ON casi.spotify_id = aa2.artist_id
+      JOIN albums al ON al.spotify_id = aa2.album_id AND al.active = 1
+      WHERE casi.artist_slug = ca.slug
+      UNION
+      SELECT at2.album_id
+      FROM album_tracks at2
+      JOIN track_artists ta ON ta.track_id = at2.track_id
+      JOIN configured_artist_spotify_ids casi ON casi.spotify_id = ta.artist_id
+      JOIN albums al ON al.spotify_id = at2.album_id AND al.active = 1
+      WHERE casi.artist_slug = ca.slug
+    )
+  ),
+  (
+    SELECT COUNT(DISTINCT track_id)
+    FROM (
+      SELECT at.track_id
+      FROM artist_tracks at
+      WHERE at.configured_artist_slug = ca.slug AND at.active = 1
+      UNION
+      SELECT ta.track_id
+      FROM track_artists ta
+      JOIN configured_artist_spotify_ids casi ON casi.spotify_id = ta.artist_id
+      JOIN tracks t ON t.spotify_id = ta.track_id AND t.active = 1
+      WHERE casi.artist_slug = ca.slug
+    )
+  )
 FROM configured_artists ca
 LEFT JOIN external_urls eu ON eu.owner_type = 'artist' AND eu.owner_id = ca.spotify_id AND eu.provider = 'spotify'
 LEFT JOIN images img ON img.owner_type = 'artist' AND img.owner_id = ca.spotify_id AND img.position = 0
-LEFT JOIN artist_albums aa ON aa.configured_artist_slug = ca.slug AND aa.active = 1
-LEFT JOIN artist_tracks at ON at.configured_artist_slug = ca.slug AND at.active = 1
 GROUP BY ca.slug
 ORDER BY COALESCE(ca.editorial_order, 999999), ca.name`)
 	if err != nil {
@@ -292,6 +328,57 @@ SELECT at.track_id, al.spotify_id, al.name
 FROM album_tracks at
 JOIN albums al ON al.spotify_id = at.album_id
 ORDER BY at.track_id, al.release_date, at.disc_number, at.track_number`)
+}
+
+func (d *Database) albumRelatedArtists(ctx context.Context) (map[string][]catalogexport.GroupCredit, error) {
+	rows, err := d.db.QueryContext(ctx, `
+SELECT DISTINCT album_id, slug, spotify_id, name, category, editorial_order
+FROM (
+  SELECT aa.album_id, ca.slug, COALESCE(ca.spotify_id, '') AS spotify_id, ca.name, ca.category, COALESCE(ca.editorial_order, 999999) AS editorial_order
+  FROM artist_albums aa
+  JOIN configured_artists ca ON ca.slug = aa.configured_artist_slug
+  WHERE aa.active = 1 AND ca.active = 1
+
+  UNION
+
+  SELECT aa.album_id, ca.slug, COALESCE(ca.spotify_id, '') AS spotify_id, ca.name, ca.category, COALESCE(ca.editorial_order, 999999) AS editorial_order
+  FROM album_artists aa
+  JOIN configured_artist_spotify_ids casi ON casi.spotify_id = aa.artist_id
+  JOIN configured_artists ca ON ca.slug = casi.artist_slug
+  JOIN albums al ON al.spotify_id = aa.album_id
+  WHERE ca.active = 1 AND al.active = 1
+
+  UNION
+
+  SELECT at.album_id, ca.slug, COALESCE(ca.spotify_id, '') AS spotify_id, ca.name, ca.category, COALESCE(ca.editorial_order, 999999) AS editorial_order
+  FROM album_tracks at
+  JOIN track_artists ta ON ta.track_id = at.track_id
+  JOIN configured_artist_spotify_ids casi ON casi.spotify_id = ta.artist_id
+  JOIN configured_artists ca ON ca.slug = casi.artist_slug
+  JOIN albums al ON al.spotify_id = at.album_id
+  WHERE ca.active = 1 AND al.active = 1
+)
+ORDER BY album_id, editorial_order, name`)
+	if err != nil {
+		return nil, fmt.Errorf("export album related artists: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := map[string][]catalogexport.GroupCredit{}
+	for rows.Next() {
+		var albumID string
+		var artist catalogexport.GroupCredit
+		var editorialOrder int
+		if err := rows.Scan(&albumID, &artist.Slug, &artist.SpotifyID, &artist.Name, &artist.Category, &editorialOrder); err != nil {
+			return nil, fmt.Errorf("scan album related artist: %w", err)
+		}
+		result[albumID] = append(result[albumID], artist)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate album related artists: %w", err)
+	}
+
+	return result, nil
 }
 
 func (d *Database) albumTracks(ctx context.Context, trackCredits map[string][]catalogexport.Credit) (map[string][]catalogexport.AlbumTrack, error) {

--- a/internal/application/catalogexport/export.go
+++ b/internal/application/catalogexport/export.go
@@ -76,29 +76,32 @@ type Artist struct {
 }
 
 type Album struct {
-	SpotifyID   string       `json:"spotify_id"`
-	Name        string       `json:"name"`
-	AlbumType   string       `json:"album_type"`
-	ReleaseDate string       `json:"release_date,omitempty"`
-	Label       string       `json:"label,omitempty"`
-	TotalTracks int          `json:"total_tracks"`
-	SpotifyURL  string       `json:"spotify_url,omitempty"`
-	ImageURL    string       `json:"image_url,omitempty"`
-	Artists     []Credit     `json:"artists"`
-	Tracks      []AlbumTrack `json:"tracks,omitempty"`
-	Copyrights  []Copyright  `json:"copyrights,omitempty"`
+	SpotifyID   string        `json:"spotify_id"`
+	Name        string        `json:"name"`
+	AlbumType   string        `json:"album_type"`
+	ReleaseDate string        `json:"release_date,omitempty"`
+	Label       string        `json:"label,omitempty"`
+	TotalTracks int           `json:"total_tracks"`
+	SpotifyURL  string        `json:"spotify_url,omitempty"`
+	ImageURL    string        `json:"image_url,omitempty"`
+	Artists     []Credit      `json:"artists"`
+	Related     []GroupCredit `json:"related_artists,omitempty"`
+	Tracks      []AlbumTrack  `json:"tracks,omitempty"`
+	Copyrights  []Copyright   `json:"copyrights,omitempty"`
 }
 
 type Track struct {
-	SpotifyID  string   `json:"spotify_id"`
-	Name       string   `json:"name"`
-	DurationMS int      `json:"duration_ms"`
-	Explicit   bool     `json:"explicit"`
-	ISRC       string   `json:"isrc,omitempty"`
-	SpotifyURL string   `json:"spotify_url,omitempty"`
-	PreviewURL string   `json:"preview_url,omitempty"`
-	Artists    []Credit `json:"artists"`
-	Albums     []Credit `json:"albums,omitempty"`
+	SpotifyID    string        `json:"spotify_id"`
+	Name         string        `json:"name"`
+	DurationMS   int           `json:"duration_ms"`
+	Explicit     bool          `json:"explicit"`
+	ISRC         string        `json:"isrc,omitempty"`
+	SpotifyURL   string        `json:"spotify_url,omitempty"`
+	PreviewURL   string        `json:"preview_url,omitempty"`
+	Artists      []Credit      `json:"artists"`
+	Albums       []Credit      `json:"albums,omitempty"`
+	ReleaseYears []string      `json:"release_years,omitempty"`
+	Groups       []GroupCredit `json:"groups,omitempty"`
 }
 
 type AlbumTrack struct {
@@ -114,6 +117,13 @@ type AlbumTrack struct {
 type Credit struct {
 	SpotifyID string `json:"spotify_id,omitempty"`
 	Name      string `json:"name"`
+}
+
+type GroupCredit struct {
+	Slug      string `json:"slug"`
+	SpotifyID string `json:"spotify_id,omitempty"`
+	Name      string `json:"name"`
+	Category  string `json:"category"`
 }
 
 type Copyright struct {
@@ -217,7 +227,7 @@ func (e ExportCatalog) Run(ctx context.Context, options Options) (Report, error)
 			return report, err
 		}
 	}
-	if err := write(filepath.Join(options.OutputDir, "tracks", "index.json"), mustJSON(Index[Track]{FormatVersion: FormatVersion, Items: trackIndex(catalog.Tracks)}), keepGenerated); err != nil {
+	if err := write(filepath.Join(options.OutputDir, "tracks", "index.json"), mustJSON(Index[Track]{FormatVersion: FormatVersion, Items: trackIndex(catalog)}), keepGenerated); err != nil {
 		return report, err
 	}
 	for _, track := range catalog.Tracks {
@@ -292,14 +302,124 @@ func albumIndex(albums []Album) []Album {
 	return items
 }
 
-func trackIndex(tracks []Track) []Track {
-	items := make([]Track, 0, len(tracks))
-	for _, track := range tracks {
+func trackIndex(catalog Catalog) []Track {
+	yearsByTrack := trackReleaseYears(catalog.Albums)
+	groupsByTrack := trackGroups(catalog.Artists, catalog.Tracks)
+	items := make([]Track, 0, len(catalog.Tracks))
+	for _, track := range catalog.Tracks {
 		track.Albums = nil
+		track.ReleaseYears = yearsByTrack[track.SpotifyID]
+		track.Groups = groupsByTrack[track.SpotifyID]
 		items = append(items, track)
 	}
 
 	return items
+}
+
+func trackReleaseYears(albums []Album) map[string][]string {
+	years := map[string]map[string]struct{}{}
+	for _, album := range albums {
+		if len(album.ReleaseDate) < 4 {
+			continue
+		}
+		year := album.ReleaseDate[:4]
+		for _, track := range album.Tracks {
+			if _, ok := years[track.SpotifyID]; !ok {
+				years[track.SpotifyID] = map[string]struct{}{}
+			}
+			years[track.SpotifyID][year] = struct{}{}
+		}
+	}
+
+	result := map[string][]string{}
+	for trackID, trackYears := range years {
+		values := make([]string, 0, len(trackYears))
+		for year := range trackYears {
+			values = append(values, year)
+		}
+		sort.Sort(sort.Reverse(sort.StringSlice(values)))
+		result[trackID] = values
+	}
+
+	return result
+}
+
+func trackGroups(artists []Artist, tracks []Track) map[string][]GroupCredit {
+	matchers := configuredArtistMatchers(artists)
+	result := map[string][]GroupCredit{}
+	for _, track := range tracks {
+		matches := []GroupCredit{}
+		seen := map[string]struct{}{}
+		for _, artist := range track.Artists {
+			keys := []string{artist.SpotifyID, artist.Name}
+			for _, matcher := range matchers {
+				if _, ok := seen[matcher.group.Slug]; ok {
+					continue
+				}
+				if matcher.matches(keys) {
+					seen[matcher.group.Slug] = struct{}{}
+					matches = append(matches, matcher.group)
+				}
+			}
+		}
+		if len(matches) > 0 {
+			result[track.SpotifyID] = matches
+		}
+	}
+
+	return result
+}
+
+type artistMatcher struct {
+	group GroupCredit
+	keys  map[string]struct{}
+}
+
+func configuredArtistMatchers(artists []Artist) []artistMatcher {
+	matchers := make([]artistMatcher, 0, len(artists))
+	for _, artist := range artists {
+		keys := map[string]struct{}{}
+		addMatcherKey(keys, artist.SpotifyID)
+		for _, spotifyID := range artist.SpotifyIDs {
+			addMatcherKey(keys, spotifyID)
+		}
+		addMatcherKey(keys, artist.Name)
+		addMatcherKey(keys, artist.PublicName)
+		for _, alias := range artist.Aliases {
+			addMatcherKey(keys, alias)
+		}
+		if len(keys) == 0 {
+			continue
+		}
+		matchers = append(matchers, artistMatcher{
+			group: GroupCredit{Slug: artist.Slug, SpotifyID: artist.SpotifyID, Name: artist.Name, Category: artist.Category},
+			keys:  keys,
+		})
+	}
+
+	return matchers
+}
+
+func (m artistMatcher) matches(values []string) bool {
+	for _, value := range values {
+		if _, ok := m.keys[matcherKey(value)]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func addMatcherKey(keys map[string]struct{}, value string) {
+	value = matcherKey(value)
+	if value == "" {
+		return
+	}
+	keys[value] = struct{}{}
+}
+
+func matcherKey(value string) string {
+	return strings.ToLower(strings.Join(strings.Fields(value), " "))
 }
 
 func searchIndex(catalog Catalog) SearchIndex {

--- a/internal/application/catalogexport/export_test.go
+++ b/internal/application/catalogexport/export_test.go
@@ -28,7 +28,10 @@ func TestExportCatalogWritesDeterministicFiles(t *testing.T) {
 	require.Contains(t, string(writer.files["generated/catalog-summary.json"]), `"format_version": 1`)
 	require.Contains(t, string(writer.files["generated/artists/index.json"]), `"wu-tang-clan"`)
 	require.Contains(t, string(writer.files["generated/albums/album-1.json"]), `"Track One"`)
+	require.Contains(t, string(writer.files["generated/albums/index.json"]), `"related_artists": [`)
 	require.Contains(t, string(writer.files["generated/tracks/track-1.json"]), `"Album One"`)
+	require.Contains(t, string(writer.files["generated/tracks/index.json"]), `"release_years": [`)
+	require.Contains(t, string(writer.files["generated/tracks/index.json"]), `"groups": [`)
 	require.Contains(t, string(writer.files["content/generated/artists/wu-tang-clan.md"]), `layout: "artist"`)
 	require.Contains(t, string(writer.files["content/generated/albums/album-1.md"]), `layout: "album"`)
 	require.Contains(t, string(writer.files["static/search-index.json"]), `"type": "artist"`)
@@ -105,6 +108,7 @@ func sampleCatalog() catalogexport.Catalog {
 			ReleaseDate: "1993-11-09",
 			TotalTracks: 1,
 			Artists:     []catalogexport.Credit{{SpotifyID: "artist-1", Name: "Wu-Tang Clan"}},
+			Related:     []catalogexport.GroupCredit{{Slug: "wu-tang-clan", SpotifyID: "artist-1", Name: "Wu-Tang Clan", Category: "core"}},
 			Tracks: []catalogexport.AlbumTrack{{
 				SpotifyID:   "track-1",
 				Name:        "Track One",

--- a/site/assets/css/main.css
+++ b/site/assets/css/main.css
@@ -304,6 +304,21 @@ select:focus {
   color: var(--muted);
 }
 
+.album-artists {
+  margin: 6px 0;
+  font-weight: 800;
+}
+
+.album-artists a {
+  color: var(--paper);
+  text-decoration: none;
+}
+
+.album-artists a:focus,
+.album-artists a:hover {
+  color: var(--gold);
+}
+
 .thumb,
 .cover {
   aspect-ratio: 1;
@@ -354,8 +369,35 @@ dd {
   font-weight: 900;
 }
 
-.toolbar {
+.toolbar,
+.filter-panel {
   max-width: 320px;
+}
+
+.filter-panel {
+  max-width: none;
+  display: grid;
+  grid-template-columns: minmax(220px, 1.3fr) repeat(3, minmax(160px, 1fr)) auto;
+  gap: 14px;
+  align-items: end;
+  margin-top: 20px;
+}
+
+.filter-panel-compact {
+  grid-template-columns: minmax(220px, 1.4fr) minmax(180px, 1fr) auto;
+}
+
+.filter-actions {
+  display: grid;
+  gap: 8px;
+  justify-items: start;
+}
+
+.filter-count {
+  margin: 0;
+  color: var(--muted);
+  font-weight: 900;
+  white-space: nowrap;
 }
 
 .detail-hero {
@@ -653,6 +695,10 @@ th {
 
   .stat-grid {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .filter-panel {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/site/assets/js/search.js
+++ b/site/assets/js/search.js
@@ -101,6 +101,91 @@
     }
   }
 
+  for (const form of document.querySelectorAll("[data-artist-filters]")) {
+    setupArtistFilters(form);
+  }
+
+  function setupArtistFilters(form) {
+    const rows = Array.from(document.querySelectorAll("[data-artist-row]"));
+    const queryInput = form.querySelector('[data-artist-filter="query"]');
+    const categorySelect = form.querySelector('[data-artist-filter="category"]');
+    const count = form.querySelector("[data-artist-filter-count]");
+    const category = new URLSearchParams(window.location.search).get("category");
+    if (category && categorySelect) {
+      categorySelect.value = category;
+    }
+
+    function applyArtistFilters() {
+      const query = normalize(queryInput ? queryInput.value : "");
+      const categoryValue = categorySelect ? categorySelect.value : "";
+      let visible = 0;
+
+      for (const row of rows) {
+        const matchesQuery = !query || normalize(row.dataset.artistText).includes(query);
+        const matchesCategory = !categoryValue || row.dataset.category === categoryValue;
+        const matches = matchesQuery && matchesCategory;
+        row.hidden = !matches;
+        if (matches) {
+          visible += 1;
+        }
+      }
+
+      if (count) {
+        count.textContent = `${visible} of ${rows.length} artists`;
+      }
+    }
+
+    form.addEventListener("input", applyArtistFilters);
+    form.addEventListener("change", applyArtistFilters);
+    form.addEventListener("reset", function () {
+      window.setTimeout(applyArtistFilters, 0);
+    });
+    applyArtistFilters();
+  }
+
+  for (const form of document.querySelectorAll("[data-track-filters]")) {
+    setupTrackFilters(form);
+  }
+
+  function setupTrackFilters(form) {
+    const rows = Array.from(document.querySelectorAll("[data-track-row]"));
+    const filters = Array.from(form.querySelectorAll("[data-track-filter]"));
+    const count = form.querySelector("[data-track-filter-count]");
+
+    function applyTrackFilters() {
+      const values = Object.fromEntries(filters.map((filter) => [filter.dataset.trackFilter, filter.value]));
+      const query = normalize(values.query);
+      let visible = 0;
+
+      for (const row of rows) {
+        const matchesQuery = !query || normalize(row.dataset.trackText).includes(query);
+        const matchesGroup = !values.group || tokenList(row.dataset.trackGroups).includes(values.group);
+        const matchesYear = !values.year || tokenList(row.dataset.trackYears).includes(values.year);
+        const matchesExplicit = !values.explicit || row.dataset.trackExplicit === values.explicit;
+        const matches = matchesQuery && matchesGroup && matchesYear && matchesExplicit;
+        row.hidden = !matches;
+        if (matches) {
+          visible += 1;
+        }
+      }
+
+      if (count) {
+        count.textContent = `${visible} of ${rows.length} tracks`;
+      }
+    }
+
+    form.addEventListener("input", applyTrackFilters);
+    form.addEventListener("change", applyTrackFilters);
+    form.addEventListener("reset", function () {
+      window.setTimeout(applyTrackFilters, 0);
+    });
+    applyTrackFilters();
+  }
+
+  function tokenList(value) {
+    return String(value || "").trim().split(/\s+/).filter(Boolean);
+  }
+
   for (const list of document.querySelectorAll("[data-random-artist-list]")) {
     const items = Array.from(list.querySelectorAll("[data-random-artist-item]"));
     const limit = Number.parseInt(list.dataset.randomLimit || "", 10) || items.length;

--- a/site/layouts/_default/album.html
+++ b/site/layouts/_default/album.html
@@ -3,9 +3,7 @@
   <section class="shell detail-hero">
     <div class="detail-media">
       {{ if $album.image_url }}
-        {{ if $album.spotify_url }}<a href="{{ $album.spotify_url }}" target="_blank" rel="noopener noreferrer" aria-label="Open {{ $album.name }} on Spotify">{{ end }}
         <img src="{{ $album.image_url }}" alt="">
-        {{ if $album.spotify_url }}</a>{{ end }}
       {{ else }}
         <span>12"</span>
       {{ end }}
@@ -14,7 +12,12 @@
       <p class="eyebrow">{{ $album.album_type }}{{ if $album.release_date }} / {{ $album.release_date }}{{ end }}</p>
       <h1>{{ $album.name }}</h1>
       {{ if $album.label }}<p>{{ $album.label }}</p>{{ end }}
-      <p>{{ range $i, $artist := $album.artists }}{{ if $i }}, {{ end }}{{ $artist.name }}{{ end }}</p>
+      {{ with $album.related_artists }}
+        <p class="album-artists">Catalog:
+          {{ range $i, $artist := . }}{{ if $i }}, {{ end }}<a href="{{ printf "artists/%s/" $artist.slug | relURL }}">{{ $artist.name }}</a>{{ end }}
+        </p>
+      {{ end }}
+      <p>Spotify credit: {{ range $i, $artist := $album.artists }}{{ if $i }}, {{ end }}{{ $artist.name }}{{ end }}</p>
       <dl class="detail-stats">
         <div><dt>Tracks</dt><dd>{{ $album.total_tracks }}</dd></div>
         <div><dt>Type</dt><dd>{{ $album.album_type }}</dd></div>

--- a/site/layouts/_default/artist.html
+++ b/site/layouts/_default/artist.html
@@ -7,8 +7,8 @@
   {{ range $albums }}
     {{ $album := . }}
     {{ $include := false }}
-    {{ range .artists }}
-      {{ if or (eq .spotify_id $artist.spotify_id) (in $artist.spotify_ids .spotify_id) }}
+    {{ range .related_artists }}
+      {{ if eq .slug $artist.slug }}
         {{ $include = true }}
       {{ end }}
     {{ end }}
@@ -20,9 +20,7 @@
   <section class="shell detail-hero">
     <div class="detail-media">
       {{ if $artist.image_url }}
-        {{ if $artist.spotify_url }}<a href="{{ $artist.spotify_url }}" target="_blank" rel="noopener noreferrer" aria-label="Open {{ $artist.name }} on Spotify">{{ end }}
         <img src="{{ $artist.image_url }}" alt="">
-        {{ if $artist.spotify_url }}</a>{{ end }}
       {{ else }}
         <span>{{ substr $artist.name 0 1 }}</span>
       {{ end }}

--- a/site/layouts/_default/artists.html
+++ b/site/layouts/_default/artists.html
@@ -3,32 +3,43 @@
   <section class="shell page-head">
     <p class="eyebrow">Editorial catalog</p>
     <h1>Artists</h1>
-    <div class="toolbar">
-      <label for="artist-filter">Filter by category</label>
-      <select id="artist-filter" data-filter-target="artist-list">
-        <option value="">All categories</option>
-        <option value="core">Core</option>
-        <option value="affiliate_group">Affiliate groups</option>
-        <option value="affiliate_artist">Affiliate artists</option>
-        <option value="producer">Producers</option>
-        <option value="collaborator">Collaborators</option>
-      </select>
-    </div>
+    <form class="filter-panel filter-panel-compact" data-artist-filters aria-label="Artist filters">
+      <div class="filter-field">
+        <label for="artist-search">Search artist</label>
+        <input id="artist-search" type="search" data-artist-filter="query" autocomplete="off">
+      </div>
+      <div class="filter-field">
+        <label for="artist-filter">Filter by category</label>
+        <select id="artist-filter" data-artist-filter="category">
+          <option value="">All categories</option>
+          <option value="core">Core</option>
+          <option value="affiliate_group">Affiliate groups</option>
+          <option value="affiliate_artist">Affiliate artists</option>
+          <option value="producer">Producers</option>
+          <option value="collaborator">Collaborators</option>
+        </select>
+      </div>
+      <div class="filter-actions">
+        <button class="button button-secondary" type="reset">Reset</button>
+        <p class="filter-count" data-artist-filter-count aria-live="polite"></p>
+      </div>
+    </form>
   </section>
   <section class="shell section">
     <div id="artist-list" class="card-grid">
       {{ range $artists }}
-        <article id="{{ .slug }}" class="item-card" data-category="{{ .category }}">
+        {{ $artistURL := printf "artists/%s/" .slug | relURL }}
+        <article id="{{ .slug }}" class="item-card" data-artist-row data-category="{{ .category }}" data-artist-text="{{ .name }} {{ .public_name }} {{ range .aliases }} {{ . }}{{ end }}">
           <div class="thumb">
             {{ if .image_url }}
-              {{ if .spotify_url }}<a href="{{ .spotify_url }}" target="_blank" rel="noopener noreferrer" aria-label="Open {{ .name }} on Spotify">{{ end }}
-              <img src="{{ .image_url }}" alt="" loading="lazy">
-              {{ if .spotify_url }}</a>{{ end }}
+              <a href="{{ $artistURL }}" aria-label="Open {{ .name }}">
+                <img src="{{ .image_url }}" alt="" loading="lazy">
+              </a>
             {{ else }}
               <span>{{ substr .name 0 1 }}</span>
             {{ end }}
           </div>
-          <h2><a href="{{ printf "artists/%s/" .slug | relURL }}">{{ .name }}</a></h2>
+          <h2><a href="{{ $artistURL }}">{{ .name }}</a></h2>
           <p>{{ replace .category "_" " " }}</p>
           <dl>
             <div><dt>Releases</dt><dd>{{ .release_count }}</dd></div>

--- a/site/layouts/_default/tracks.html
+++ b/site/layouts/_default/tracks.html
@@ -1,23 +1,72 @@
 {{ define "main" }}
   {{ $tracks := (index hugo.Data.generated.tracks "index").items }}
+  {{ $groupOptions := slice }}
+  {{ $yearOptions := slice }}
+  {{ range $tracks }}
+    {{ range .groups }}
+      {{ $groupOptions = $groupOptions | append (printf "%s\t%s" .name .slug) }}
+    {{ end }}
+    {{ range .release_years }}
+      {{ $yearOptions = $yearOptions | append . }}
+    {{ end }}
+  {{ end }}
   <section class="shell page-head">
     <p class="eyebrow">Songs</p>
     <h1>Tracks</h1>
+    <form class="filter-panel" data-track-filters aria-label="Track filters">
+      <div class="filter-field">
+        <label for="track-search">Search</label>
+        <input id="track-search" type="search" data-track-filter="query" autocomplete="off">
+      </div>
+      <div class="filter-field">
+        <label for="track-group-filter">Group / artist</label>
+        <select id="track-group-filter" data-track-filter="group">
+          <option value="">All groups / artists</option>
+          {{ range sort (uniq $groupOptions) }}
+            {{ $parts := split . "\t" }}
+            <option value="{{ index $parts 1 }}">{{ index $parts 0 }}</option>
+          {{ end }}
+        </select>
+      </div>
+      <div class="filter-field">
+        <label for="track-year-filter">Year</label>
+        <select id="track-year-filter" data-track-filter="year">
+          <option value="">All years</option>
+          {{ range sort (uniq $yearOptions) }}
+            <option value="{{ . }}">{{ . }}</option>
+          {{ end }}
+        </select>
+      </div>
+      <div class="filter-field">
+        <label for="track-explicit-filter">Explicit</label>
+        <select id="track-explicit-filter" data-track-filter="explicit">
+          <option value="">All tracks</option>
+          <option value="true">Explicit</option>
+          <option value="false">Clean</option>
+        </select>
+      </div>
+      <div class="filter-actions">
+        <button class="button button-secondary" type="reset" data-track-filter-reset>Reset</button>
+        <p class="filter-count" data-track-filter-count aria-live="polite"></p>
+      </div>
+    </form>
   </section>
   <section class="shell section">
     <div class="table-wrap">
       <table>
-        <thead><tr><th>Track</th><th>Artists</th><th>Duration</th><th>Explicit</th></tr></thead>
+        <thead><tr><th>Track</th><th>Artists</th><th>Year</th><th>Duration</th><th>Explicit</th><th>Spotify</th></tr></thead>
         <tbody>
           {{ range $tracks }}
-            <tr id="{{ .spotify_id }}">
-              <td>{{ if .spotify_url }}<a href="{{ .spotify_url }}">{{ .name }}</a>{{ else }}{{ .name }}{{ end }}</td>
+            <tr id="{{ .spotify_id }}" data-track-row data-track-text="{{ .name }} {{ range .artists }} {{ .name }}{{ end }} {{ range .groups }} {{ .name }}{{ end }}" data-track-groups="{{ range .groups }} {{ .slug }}{{ end }}" data-track-years="{{ range .release_years }} {{ . }}{{ end }}" data-track-explicit="{{ .explicit }}">
+              <td><a href="#{{ .spotify_id }}">{{ .name }}</a></td>
               <td>{{ range $i, $artist := .artists }}{{ if $i }}, {{ end }}{{ $artist.name }}{{ end }}</td>
+              <td>{{ with .release_years }}{{ delimit . ", " }}{{ else }}Unknown{{ end }}</td>
               <td>{{ div .duration_ms 1000 }}s</td>
               <td>{{ if .explicit }}Yes{{ else }}No{{ end }}</td>
+              <td>{{ if .spotify_url }}<a class="spotify-link" href="{{ .spotify_url }}" target="_blank" rel="noopener noreferrer">Open in Spotify</a>{{ end }}</td>
             </tr>
           {{ else }}
-            <tr><td colspan="4">No tracks exported yet.</td></tr>
+            <tr><td colspan="6">No tracks exported yet.</td></tr>
           {{ end }}
         </tbody>
       </table>

--- a/site/layouts/partials/album-list.html
+++ b/site/layouts/partials/album-list.html
@@ -1,16 +1,46 @@
+{{ $catalogArtists := (index hugo.Data.generated.artists "index").items }}
+{{ $artistURLsBySpotifyID := dict }}
+{{ range $catalogArtists }}
+  {{ $artistURL := printf "artists/%s/" .slug | relURL }}
+  {{ if .spotify_id }}
+    {{ $artistURLsBySpotifyID = merge $artistURLsBySpotifyID (dict .spotify_id $artistURL) }}
+  {{ end }}
+  {{ range .spotify_ids }}
+    {{ $artistURLsBySpotifyID = merge $artistURLsBySpotifyID (dict . $artistURL) }}
+  {{ end }}
+{{ end }}
 <div class="album-grid">
   {{ range . }}
+    {{ $albumURL := printf "albums/%s/" .spotify_id | relURL }}
     <article id="{{ .spotify_id }}" class="album-card">
       <div class="cover">
         {{ if .image_url }}
-          {{ if .spotify_url }}<a href="{{ .spotify_url }}" target="_blank" rel="noopener noreferrer" aria-label="Open {{ .name }} on Spotify">{{ end }}
-          <img src="{{ .image_url }}" alt="" loading="lazy">
-          {{ if .spotify_url }}</a>{{ end }}
+          <a href="{{ $albumURL }}" aria-label="Open {{ .name }}">
+            <img src="{{ .image_url }}" alt="" loading="lazy">
+          </a>
         {{ else }}
           <span>12"</span>
         {{ end }}
       </div>
-      <h3><a href="{{ printf "albums/%s/" .spotify_id | relURL }}">{{ .name }}</a></h3>
+      <h3><a href="{{ $albumURL }}">{{ .name }}</a></h3>
+      {{ $displayArtists := .related_artists }}
+      {{ if not $displayArtists }}
+        {{ $displayArtists = .artists }}
+      {{ end }}
+      {{ with $displayArtists }}
+        <p class="album-artists">
+          {{ range $i, $artist := . }}
+            {{ if $i }}, {{ end }}
+            {{ $artistURL := "" }}
+            {{ if $artist.slug }}
+              {{ $artistURL = printf "artists/%s/" $artist.slug | relURL }}
+            {{ else }}
+              {{ $artistURL = index $artistURLsBySpotifyID $artist.spotify_id }}
+            {{ end }}
+            {{ if $artistURL }}<a href="{{ $artistURL }}">{{ $artist.name }}</a>{{ else }}{{ $artist.name }}{{ end }}
+          {{ end }}
+        </p>
+      {{ end }}
       <p>{{ .album_type }}{{ if .release_date }} / {{ .release_date }}{{ end }}</p>
       {{ if .spotify_url }}<a class="spotify-link" href="{{ .spotify_url }}" target="_blank" rel="noopener noreferrer">Open in Spotify</a>{{ end }}
     </article>

--- a/site/layouts/partials/artist-list.html
+++ b/site/layouts/partials/artist-list.html
@@ -4,17 +4,18 @@
 <div class="card-grid"{{ if $randomize }} data-random-artist-list data-random-limit="{{ $limit }}"{{ end }}>
   {{ range $index, $artist := $artists }}
     {{ $initiallyHidden := and $randomize (gt $limit 0) (ge $index $limit) }}
+    {{ $artistURL := printf "artists/%s/" $artist.slug | relURL }}
     <article class="item-card"{{ if $randomize }} data-random-artist-item{{ end }}{{ if $initiallyHidden }} hidden{{ end }}>
       <div class="thumb">
         {{ if $artist.image_url }}
-          {{ if $artist.spotify_url }}<a href="{{ $artist.spotify_url }}" target="_blank" rel="noopener noreferrer" aria-label="Open {{ $artist.name }} on Spotify">{{ end }}
-          <img src="{{ $artist.image_url }}" alt="" loading="lazy">
-          {{ if $artist.spotify_url }}</a>{{ end }}
+          <a href="{{ $artistURL }}" aria-label="Open {{ $artist.name }}">
+            <img src="{{ $artist.image_url }}" alt="" loading="lazy">
+          </a>
         {{ else }}
           <span>{{ substr $artist.name 0 1 }}</span>
         {{ end }}
       </div>
-      <h3><a href="{{ printf "artists/%s/" $artist.slug | relURL }}">{{ $artist.name }}</a></h3>
+      <h3><a href="{{ $artistURL }}">{{ $artist.name }}</a></h3>
       <p>{{ replace $artist.category "_" " " }}</p>
       {{ if $artist.spotify_url }}<a class="spotify-link" href="{{ $artist.spotify_url }}" target="_blank" rel="noopener noreferrer">Open in Spotify</a>{{ end }}
     </article>


### PR DESCRIPTION
This commit introduces significant improvements to the artist and track data, as well as new filtering features on the website.

Artist data has been enhanced by adding `aliases` to several `affiliate_group` artists in `data/artists.yaml`. This allows for more comprehensive search and identification of these groups.

On the frontend, new JavaScript functionality has been implemented:
- `setupArtistFilters`: This function enables filtering of artists by query and category. It updates the visibility of artist rows and displays a count of visible artists.
- `setupTrackFilters`: This function provides filtering for tracks based on a query, similarly updating visibility and counts.

CSS styling has been added for the new filter panel, including `.filter-panel`, `.filter-panel-group`, and `.filter-count` to provide a clean and responsive layout for the filtering controls. Media queries ensure the filter panel adapts to smaller screens.
