### PR TITLE
feat: gracefully handle Spotify API rate limits during sync

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -37,7 +37,7 @@ The sync identity and review identity must be separate GitHub Apps or bot creden
 
 Hugo JSON exports are ignored by Git and regenerated during CI and Pages deployment.
 
-`catalog-sync.yml` runs `sync --resume`. If Spotify returns a 429 that cannot be waited out inside the job, the sync command records completed artists in SQLite, writes a partial snapshot, and the workflow still opens or updates the catalog PR with that checkpoint before failing the job. The next scheduled or manual run resumes from the latest compatible partial run and skips artists whose Spotify IDs have not changed.
+`catalog-sync.yml` runs `sync --resume`. If Spotify returns a 429 that cannot be waited out inside the job, the sync command records completed artists in SQLite, writes a partial snapshot, emits a warning, and exits successfully so the workflow can open or update the catalog PR with that checkpoint. The next scheduled or manual run resumes from the latest compatible partial run and skips artists whose Spotify IDs have not changed.
 
 Mergify queues matching PRs and squash-merges them after CI passes. The queue is configured for in-place checks (`max_parallel_checks: 1`, `batch_size: 1`, identical queue and merge conditions) so it remains compatible with `main` requiring branches to be up to date before merging.
 

--- a/internal/adapters/inbound/cli/cli.go
+++ b/internal/adapters/inbound/cli/cli.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -190,16 +191,25 @@ func executeSync(ctx context.Context, args []string, stdout, stderr io.Writer, s
 
 	printSyncReport(stdout, report)
 	if err != nil {
+		exitCode := syncErrorExitCode(err, nil)
 		if !options.dryRun && report.RunID > 0 {
 			if snapshotErr := repository.WriteSnapshot(ctx, options.snapshotPath); snapshotErr != nil {
 				_, _ = fmt.Fprintf(stderr, "sync: write partial snapshot: %v\n", snapshotErr)
+				exitCode = syncErrorExitCode(err, snapshotErr)
 			}
+		}
+		if exitCode == 0 {
+			_, _ = fmt.Fprintf(stderr, "sync: warning: Spotify quota exceeded or rate limit reached; progress saved as partial run and the next sync can resume from this checkpoint: %v\n", err)
+			for _, item := range report.Errors {
+				_, _ = fmt.Fprintf(stderr, "- %s: %v\n", item.Slug, item.Err)
+			}
+			return 0
 		}
 		_, _ = fmt.Fprintf(stderr, "sync: %v\n", err)
 		for _, item := range report.Errors {
 			_, _ = fmt.Fprintf(stderr, "- %s: %v\n", item.Slug, item.Err)
 		}
-		return 1
+		return exitCode
 	}
 
 	if !options.dryRun {
@@ -210,6 +220,15 @@ func executeSync(ctx context.Context, args []string, stdout, stderr io.Writer, s
 	}
 
 	return 0
+}
+
+func syncErrorExitCode(err error, snapshotErr error) int {
+	var partialErr *catalogsync.PartialSyncError
+	if snapshotErr == nil && errors.As(err, &partialErr) {
+		return 0
+	}
+
+	return 1
 }
 
 func parseSyncOptions(args []string) (syncOptions, error) {

--- a/internal/adapters/inbound/cli/sync_internal_test.go
+++ b/internal/adapters/inbound/cli/sync_internal_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/javiyt/spotwufamily/internal/application/catalogsync"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncErrorExitCodeReturnsSuccessForPartialSync(t *testing.T) {
+	err := &catalogsync.PartialSyncError{Err: errors.New("quota exceeded")}
+
+	require.Equal(t, 0, syncErrorExitCode(err, nil))
+}
+
+func TestSyncErrorExitCodeReturnsFailureForPartialSyncSnapshotError(t *testing.T) {
+	err := &catalogsync.PartialSyncError{Err: errors.New("quota exceeded")}
+
+	require.Equal(t, 1, syncErrorExitCode(err, errors.New("snapshot failed")))
+}
+
+func TestSyncErrorExitCodeReturnsFailureForRegularError(t *testing.T) {
+	require.Equal(t, 1, syncErrorExitCode(errors.New("spotify down"), nil))
+}

--- a/internal/application/catalogsync/sync.go
+++ b/internal/application/catalogsync/sync.go
@@ -95,6 +95,26 @@ type ArtistError struct {
 	Err  error
 }
 
+type PartialSyncError struct {
+	Err error
+}
+
+func (e *PartialSyncError) Error() string {
+	if e == nil || e.Err == nil {
+		return "sync aborted after Spotify rate limit; progress saved as partial run"
+	}
+
+	return fmt.Sprintf("sync aborted after Spotify rate limit; progress saved as partial run: %v", e.Err)
+}
+
+func (e *PartialSyncError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+
+	return e.Err
+}
+
 type ProgressEvent struct {
 	Stage           ProgressStage
 	ArtistSlug      string
@@ -265,7 +285,7 @@ func (s SyncCatalog) Run(ctx context.Context, options Options) (Report, error) {
 	progress(options.Progress, ProgressEvent{Stage: ProgressRunFinished, RunID: runID, Stats: report.Stats})
 
 	if abortErr != nil {
-		return report, fmt.Errorf("sync aborted after Spotify rate limit; progress saved as partial run: %w", abortErr)
+		return report, &PartialSyncError{Err: abortErr}
 	}
 	if report.ArtistsFailed > 0 {
 		return report, fmt.Errorf("%d artist syncs failed", report.ArtistsFailed)

--- a/internal/application/catalogsync/sync_test.go
+++ b/internal/application/catalogsync/sync_test.go
@@ -201,6 +201,8 @@ func TestSyncCatalogAbortsAfterSpotifyQuotaExceeded(t *testing.T) {
 	report, err := usecase.Run(context.Background(), catalogsync.Options{CatalogPath: "ignored"})
 
 	require.ErrorContains(t, err, "sync aborted after Spotify rate limit")
+	var partialErr *catalogsync.PartialSyncError
+	require.ErrorAs(t, err, &partialErr)
 	require.Equal(t, 1, report.ArtistsFailed)
 	require.Zero(t, report.ArtistsProcessed)
 	require.Equal(t, []string{"34EP7KEpOjXcM2TCat1ISk"}, fetcher.artistIDs)


### PR DESCRIPTION
The `sync` command now exits successfully with a warning when a Spotify API rate limit is encountered, but progress has been saved as a partial run. Previously, the command would exit with a non-zero status code, causing CI jobs to fail even when a partial snapshot was successfully written.

This change allows the CI workflow to continue and open/update the catalog PR with the checkpointed progress, enabling subsequent runs to resume from where they left off. A new `sync_internal_test.go` file has been added to test this behavior.

The documentation has been updated to reflect this change.
