### PR TITLE
feat: Add GitHub Pages preview deployments

### DIFF
--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -1,0 +1,72 @@
+name: Pages Preview
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: write
+  deployments: write
+  pull-requests: read
+
+concurrency:
+  group: pages-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: deploy-pages-preview
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    environment:
+      name: pages-preview
+      url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.pull_request.number }}/
+    env:
+      PREVIEW_PATH: pr-preview/pr-${{ github.event.pull_request.number }}
+      PREVIEW_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.pull_request.number }}/
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        if: ${{ github.event.action != 'closed' }}
+        uses: actions/setup-go@v7.0.0
+        with:
+          go-version: "1.25.x"
+          cache: true
+
+      - name: Setup Hugo
+        if: ${{ github.event.action != 'closed' }}
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: "0.164.0"
+          extended: true
+
+      - name: Verify and export
+        if: ${{ github.event.action != 'closed' }}
+        run: |
+          go run ./cmd/spotwufamily db verify
+          go run ./cmd/spotwufamily export
+
+      - name: Build preview
+        if: ${{ github.event.action != 'closed' }}
+        run: go run ./cmd/spotwufamily site build --source site --destination ../public --base-url "${PREVIEW_URL}"
+
+      - name: Verify preview artifact
+        if: ${{ github.event.action != 'closed' }}
+        run: test -d public && test -f public/index.html
+
+      - name: Publish preview
+        if: ${{ github.event.action != 'closed' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PAGES_COMMIT_MESSAGE: "deploy: publish PR #${{ github.event.pull_request.number }} preview"
+        run: bash scripts/automation/publish-pages.sh public "${PREVIEW_PATH}"
+
+      - name: Remove preview
+        if: ${{ github.event.action == 'closed' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PAGES_COMMIT_MESSAGE: "deploy: remove PR #${{ github.event.pull_request.number }} preview"
+        run: bash scripts/automation/remove-pages-preview.sh "${PREVIEW_PATH}"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,12 +14,11 @@ on:
       - "go.mod"
       - "go.sum"
       - ".github/workflows/pages.yml"
+      - "scripts/automation/publish-pages.sh"
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: pages
@@ -45,33 +44,19 @@ jobs:
           hugo-version: "0.164.0"
           extended: true
 
-      - name: Configure Pages
-        uses: actions/configure-pages@v6
-
       - name: Verify and export
         run: |
           go run ./cmd/spotwufamily db verify
           go run ./cmd/spotwufamily export
 
       - name: Build Hugo
-        run: go run ./cmd/spotwufamily site build --source site --destination ../public
+        run: go run ./cmd/spotwufamily site build --source site --destination ../public --base-url "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
 
       - name: Verify Pages artifact
         run: test -d public && test -f public/index.html
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: public
-
-  deploy:
-    name: deploy-pages
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+      - name: Publish Pages
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PAGES_COMMIT_MESSAGE: "deploy: publish site"
+        run: bash scripts/automation/publish-pages.sh public

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -6,6 +6,7 @@ Workflows:
 - `catalog-sync.yml`: runs scheduled or manual Spotify sync, regenerates SQLite and the snapshot, and opens or updates one catalog PR.
 - `catalog-pr-review.yml`: approves generated catalog PRs only after checking trusted metadata, labels and changed paths.
 - `pages.yml`: verifies exports, builds Hugo and deploys GitHub Pages after merge to `main`.
+- `pages-preview.yml`: deploys same-repository PR branches to a Pages preview under `/pr-preview/pr-<number>/` and removes the preview when the PR closes.
 
 Current local build command:
 
@@ -14,6 +15,8 @@ go run ./cmd/spotwufamily site build
 ```
 
 The site is configured for `https://javiyt.github.io/spotwufamily/` and must keep links working under that subpath.
+
+GitHub Pages must be configured as `Deploy from branch` with branch `gh-pages` and folder `/ (root)`. Repository Actions workflow permissions must allow read and write access so `GITHUB_TOKEN` can push to `gh-pages`. Production deploys publish to the branch root and preserve `pr-preview/`; PR preview deploys publish only under the PR-specific preview path.
 
 Required repository secrets:
 

--- a/internal/adapters/inbound/cli/cli.go
+++ b/internal/adapters/inbound/cli/cli.go
@@ -86,6 +86,7 @@ func executeSite(ctx context.Context, args []string, stdout, stderr io.Writer) i
 
 	source := "site"
 	destination := "/tmp/spotwufamily-site"
+	baseURL := ""
 	for i := 1; i < len(args); i++ {
 		switch args[i] {
 		case "--source":
@@ -100,6 +101,12 @@ func executeSite(ctx context.Context, args []string, stdout, stderr io.Writer) i
 				return optionError(stderr, "site build", "--destination requires a value")
 			}
 			destination = args[i]
+		case "--base-url":
+			i++
+			if i >= len(args) {
+				return optionError(stderr, "site build", "--base-url requires a value")
+			}
+			baseURL = args[i]
 		default:
 			return optionError(stderr, "site build", fmt.Sprintf("unknown option %q", args[i]))
 		}
@@ -108,6 +115,9 @@ func executeSite(ctx context.Context, args []string, stdout, stderr io.Writer) i
 	commandArgs := []string{"--source", source, "--minify"}
 	if destination != "" {
 		commandArgs = append(commandArgs, "--destination", destination)
+	}
+	if baseURL != "" {
+		commandArgs = append(commandArgs, "--baseURL", baseURL)
 	}
 	cmd := exec.CommandContext(ctx, "hugo", commandArgs...)
 	cmd.Stdout = stdout
@@ -2222,7 +2232,7 @@ func printExportHelp(w io.Writer) {
 }
 
 func printSiteHelp(w io.Writer) {
-	_, _ = fmt.Fprintln(w, "usage: spotwufamily site build [--source site] [--destination /tmp/spotwufamily-site]")
+	_, _ = fmt.Fprintln(w, "usage: spotwufamily site build [--source site] [--destination /tmp/spotwufamily-site] [--base-url https://example.com/]")
 }
 
 func printAuditHelp(w io.Writer) {

--- a/scripts/automation/publish-pages.sh
+++ b/scripts/automation/publish-pages.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_dir="${1:?source directory is required}"
+target_path="${2:-}"
+commit_message="${PAGES_COMMIT_MESSAGE:-deploy pages}"
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+token="${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+deploy_dir="$(mktemp -d)"
+remote="https://x-access-token:${token}@github.com/${repo}.git"
+
+if git ls-remote --exit-code --heads "${remote}" gh-pages >/dev/null 2>&1; then
+  git clone --depth 1 --branch gh-pages "${remote}" "${deploy_dir}"
+else
+  git init "${deploy_dir}"
+  git -C "${deploy_dir}" checkout --orphan gh-pages
+fi
+
+git -C "${deploy_dir}" config user.name "github-actions[bot]"
+git -C "${deploy_dir}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+if [[ -z "${target_path}" ]]; then
+  find "${deploy_dir}" -mindepth 1 -maxdepth 1 ! -name .git ! -name pr-preview -exec rm -rf {} +
+  cp -R "${source_dir%/}/." "${deploy_dir}/"
+else
+  rm -rf "${deploy_dir}/${target_path}"
+  mkdir -p "${deploy_dir}/${target_path}"
+  cp -R "${source_dir%/}/." "${deploy_dir}/${target_path}/"
+fi
+
+touch "${deploy_dir}/.nojekyll"
+git -C "${deploy_dir}" add -A
+if git -C "${deploy_dir}" diff --cached --quiet; then
+  echo "No Pages changes to publish."
+  exit 0
+fi
+
+git -C "${deploy_dir}" commit -m "${commit_message}"
+git -C "${deploy_dir}" push "${remote}" HEAD:gh-pages

--- a/scripts/automation/remove-pages-preview.sh
+++ b/scripts/automation/remove-pages-preview.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target_path="${1:?target path is required}"
+commit_message="${PAGES_COMMIT_MESSAGE:-remove pages preview}"
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+token="${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+deploy_dir="$(mktemp -d)"
+remote="https://x-access-token:${token}@github.com/${repo}.git"
+
+if ! git ls-remote --exit-code --heads "${remote}" gh-pages >/dev/null 2>&1; then
+  echo "No gh-pages branch found."
+  exit 0
+fi
+
+git clone --depth 1 --branch gh-pages "${remote}" "${deploy_dir}"
+if [[ ! -e "${deploy_dir}/${target_path}" ]]; then
+  echo "No preview found at ${target_path}."
+  exit 0
+fi
+
+git -C "${deploy_dir}" config user.name "github-actions[bot]"
+git -C "${deploy_dir}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+rm -rf "${deploy_dir}/${target_path}"
+touch "${deploy_dir}/.nojekyll"
+
+git -C "${deploy_dir}" add -A
+if git -C "${deploy_dir}" diff --cached --quiet; then
+  echo "No Pages preview changes to publish."
+  exit 0
+fi
+
+git -C "${deploy_dir}" commit -m "${commit_message}"
+git -C "${deploy_dir}" push "${remote}" HEAD:gh-pages

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -12,7 +12,7 @@
     <a class="skip-link" href="#main">Skip to content</a>
     <header class="site-header">
       <div class="shell header-grid">
-        <a class="brand" href="{{ site.Params.basePath }}" aria-label="Spot Wu Family home">
+        <a class="brand" href="{{ "" | relURL }}" aria-label="Spot Wu Family home">
           <img src="{{ relURL "images/spot-wu-mark.svg" }}" alt="" width="48" height="48">
           <span>Spot Wu Family</span>
         </a>
@@ -33,7 +33,7 @@
       </div>
     </footer>
     <script>
-      window.SpotWuBasePath = "{{ site.Params.basePath }}";
+      window.SpotWuBasePath = "{{ "" | relURL }}";
       window.SpotWuSearchIndex = "{{ relURL "search-index.json" }}";
     </script>
     {{ $js := resources.Get "js/search.js" | minify | fingerprint }}


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to deploy preview environments for pull requests.

The `pages-preview.yml` workflow will:
- Deploy a preview of the website to a unique URL for each pull request.
- Build the Hugo site with the correct base URL for the preview.
- Remove the preview deployment when the pull request is closed.

Additionally, the existing `pages.yml` workflow has been updated to use a custom script for publishing, aligning with the preview deployment strategy. This ensures consistent deployment mechanisms.

The documentation has also been updated to reflect these new automation features.