### PR TITLE
ci: Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: write
+  deployments: write
 
 concurrency:
   group: pages
@@ -26,8 +27,11 @@ concurrency:
 
 jobs:
   build:
-    name: build-pages
+    name: deploy-pages
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -55,7 +59,7 @@ jobs:
       - name: Verify Pages artifact
         run: test -d public && test -f public/index.html
 
-      - name: Publish Pages
+      - name: Deploy Pages
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PAGES_COMMIT_MESSAGE: "deploy: publish site"


### PR DESCRIPTION
This commit updates the GitHub Pages workflow to use the new native deployment functionality.

The workflow now includes:
- `deployments: write` permission to allow the workflow to create and manage deployments.
- `environment` configuration for `github-pages` to properly link the deployment to the GitHub Pages environment.
- Renamed job from `build-pages` to `deploy-pages` and step from `Publish Pages` to `Deploy Pages` to better reflect the action being performed.